### PR TITLE
Catalyst test added

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -15,6 +15,7 @@ workflows:
     - errcheck:
     - go-test:
     after_run:
+    - test_catalyst
     - test_cloudkit
     - test_objc
     - test_xcode_8
@@ -22,6 +23,16 @@ workflows:
     - test_workspace
     - test_tvos
     - test_no_app_dsym
+
+  test_catalyst:
+    envs:
+    - SAMPLE_APP_URL: https://github.com/bitrise-io/CatalystSample.git
+    - BRANCH: master
+    - BITRISE_PROJECT_PATH: Catalyst Sample.xcodeproj
+    - BITRISE_SCHEME: Catalyst Sample
+    - OUTPUT_TOOL: xcodebuild
+    after_run:
+    - _common
 
   test_cloudkit:
     envs:

--- a/step.yml
+++ b/step.yml
@@ -233,7 +233,7 @@ inputs:
       title: "Generated Artifact Name"
       description: |-
         This name will be used as basename for the generated .xcarchive, .ipa and .dSYM.zip files.
-  - xcodebuild_options: "-destination "generic/platform=iOS""
+  - xcodebuild_options: -destination "generic/platform=iOS"
     opts:
       category: Debug
       title: Additional options for xcodebuild call

--- a/step.yml
+++ b/step.yml
@@ -233,7 +233,7 @@ inputs:
       title: "Generated Artifact Name"
       description: |-
         This name will be used as basename for the generated .xcarchive, .ipa and .dSYM.zip files.
-  - xcodebuild_options: ""
+  - xcodebuild_options: "-destination "generic/platform=iOS""
     opts:
       category: Debug
       title: Additional options for xcodebuild call


### PR DESCRIPTION
As the step is intended to archive iOS projects and export an iOS IPA file from the generated archive, I added `-destination "generic/platform=iOS"` as default `Additional options for xcodebuild call`