### PR TITLE
TOOL-1837 Use duplicate Common name certificates too for codesigning lookup

### DIFF
--- a/main.go
+++ b/main.go
@@ -603,7 +603,8 @@ is available in the $BITRISE_XCODE_RAW_RESULT_TEXT_PATH environment variable`)
 				if err != nil {
 					fail("Failed to get installed certificates, error: %s", err)
 				}
-				certs = certificateutil.FilterValidCertificateInfos(certs).ValidCertificates
+				certInfo := certificateutil.FilterValidCertificateInfos(certs)
+				certs = append(certInfo.ValidCertificates, certInfo.DuplicatedCertificates...)
 
 				log.Debugf("Installed certificates:")
 				for _, certInfo := range certs {


### PR DESCRIPTION
If there are multiple certificates with the same common name (For example two different distribution certificates), the Resolving CodeSignGroups... phase possibly will not find certificates referenced in provisioning profiles.