### PR TITLE
go-xcode dep updated

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -40,7 +40,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:632a63518c5cd8284df748c0762e4fabd84ead5f2427f8e9ff8626a87ea17afb"
+  digest = "1:90f6a886cb0e3200795dd3b2f0f79ef378a085d7dd36f71eefc45f880e2cfb3a"
   name = "github.com/bitrise-io/go-xcode"
   packages = [
     "certificateutil",
@@ -56,7 +56,7 @@
     "xcpretty",
   ]
   pruneopts = "UT"
-  revision = "da61baacf830c2d5a1a83214538aaad789426e20"
+  revision = "13f817b37b1c63bfa16ae226f4389f026accfe87"
 
 [[projects]]
   branch = "master"

--- a/vendor/github.com/bitrise-io/go-xcode/xcarchive/xcarchive.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcarchive/xcarchive.go
@@ -1,7 +1,6 @@
 package xcarchive
 
 import (
-	"errors"
 	"path/filepath"
 	"strings"
 
@@ -10,10 +9,6 @@ import (
 	"github.com/bitrise-io/go-utils/ziputil"
 	"github.com/bitrise-io/go-xcode/plistutil"
 	"github.com/bitrise-io/go-xcode/utility"
-)
-
-var (
-	errNoDsymFound = errors.New("no dsym found")
 )
 
 // IsMacOS try to find the Contents dir under the .app/.
@@ -87,9 +82,6 @@ func findDSYMs(archivePath string) ([]string, []string, error) {
 		} else {
 			frameworkDSYMs = append(frameworkDSYMs, dsym)
 		}
-	}
-	if len(appDSYMs) == 0 && len(frameworkDSYMs) == 0 {
-		return []string{}, []string{}, errNoDsymFound
 	}
 
 	return appDSYMs, frameworkDSYMs, nil


### PR DESCRIPTION
https://bitrise.atlassian.net/browse/STEP-303

### Context
Based on [this](https://developer.apple.com/documentation/xcode/building_your_app_to_include_debugging_information#3403353) document the generation of the build symbols is optional, so the `go-xcode` package has [updated](https://github.com/bitrise-io/go-xcode/pull/98) to not return an error if there is not any dSYM found. The dependency has to be updated here.