### PR TITLE
Fix auto-detect export method issuer

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -82,7 +82,7 @@ workflows:
     - COMMIT: "65cd120bf4459c2881cfe2b731395b4efc53855d"
     - BITRISE_PROJECT_PATH: ios-simple-objc/ios-simple-objc.xcodeproj
     - BITRISE_SCHEME: ios-simple-objc
-    - EXPORT_METHOD: development
+    - EXPORT_METHOD: auto-detect
     - OUTPUT_TOOL: xcodebuild
     - FORCE_CODE_SIGN_IDENTITY: "iPhone Developer: Dev Portal Bot Bitrise"
     - TEAM_ID: 72SA8V3WYL


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

xcarchive's distribution type not gets passed to the IPA export process, which makes the step failing with an error like:

```
[31;1mFailed to find Codesign Groups[0m

generated export options content:

<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
	<dict>
	</dict>
</plist> <nil>

[13:19:25] xcodebuild "-exportArchive" "-archivePath" ....
...
** EXPORT FAILED **
...
```

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes

- add e2e test case to reproduce the issue
- fix missing archive's export method

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
