### PR TITLE
Fix empty error in case of IPA export failure.

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -6,6 +6,12 @@ workflows:
     steps:
     - git::https://github.com/bitrise-steplib/steps-check.git:
 
+  e2e:
+    steps:
+      - git::https://github.com/bitrise-steplib/steps-check.git:
+          inputs:
+            - workflow: e2e
+
   sample:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/sample-apps-ios-simple-objc.git

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -189,7 +189,7 @@ workflows:
     - BITRISE_PROJECT_PATH: NPO Live.xcworkspace
     - BITRISE_SCHEME: "NPO Live"
     - ARTIFACT_NAME: ios-simple-objc(1234)
-    - FORCE_CODE_SIGN_IDENTITY: ""
+    - FORCE_CODE_SIGN_IDENTITY: "iPhone Developer: Dev Portal Bot Bitrise"
     - FORCE_TEAM_ID: ""
     - FORCE_PROV_PROFILE_SPECIFIER: ""
     - IPA_EXPORT_METHOD: development

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -1,4 +1,4 @@
-format_version: 11
+format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 app:
@@ -173,25 +173,6 @@ workflows:
     - FORCE_CODE_SIGN_IDENTITY: "iPhone Developer: Dev Portal Bot Bitrise"
     - FORCE_TEAM_ID: 72SA8V3WYL
     - FORCE_PROV_PROFILE_SPECIFIER: "BitriseBot-Wildcard"
-    - IPA_EXPORT_METHOD: development
-    - IPA_EXPORT_ICLOUD_CONTAINER_ENVIRONMENT: ""
-    - XCODE_OUTPUT_TOOL: xcodebuild
-    after_run:
-    - _run
-    - _check_outputs
-    - _check_exported_artifacts
-
-  test_tvos:
-    envs:
-    - TEST_APP_URL: https://github.com/bitrise-samples/sample-apps-tvos-swift.git
-    - TEST_APP_BRANCH: "master"
-    - TEST_APP_COMMIT: ""
-    - BITRISE_PROJECT_PATH: NPO Live.xcworkspace
-    - BITRISE_SCHEME: "NPO Live"
-    - ARTIFACT_NAME: ios-simple-objc(1234)
-    - FORCE_CODE_SIGN_IDENTITY: "iPhone Developer: Dev Portal Bot Bitrise"
-    - FORCE_TEAM_ID: ""
-    - FORCE_PROV_PROFILE_SPECIFIER: ""
     - IPA_EXPORT_METHOD: development
     - IPA_EXPORT_ICLOUD_CONTAINER_ENVIRONMENT: ""
     - XCODE_OUTPUT_TOOL: xcodebuild

--- a/main.go
+++ b/main.go
@@ -653,8 +653,8 @@ func (s XcodeArchiveStep) xcodeIPAExport(opts xcodeIPAExportOpts) (xcodeIPAExpor
 		fmt.Println()
 		logWithTimestamp(colorstring.Green, xcprettyCmd.PrintableCmd())
 
-		xcodebuildLog, err := xcprettyCmd.Run()
-		if err != nil {
+		xcodebuildLog, exportErr := xcprettyCmd.Run()
+		if exportErr != nil {
 			out.XcodebuildLog = xcodebuildLog
 
 			log.Warnf(`If you can't find the reason of the error in the log, please check the raw-xcodebuild-output.log
@@ -679,14 +679,14 @@ The logs directory is stored in $BITRISE_DEPLOY_DIR, and its full path
 is available in the $BITRISE_IDEDISTRIBUTION_LOGS_PATH environment variable`)
 			}
 
-			return out, fmt.Errorf("export failed, error: %s", err)
+			return out, fmt.Errorf("export failed, error: %s", exportErr)
 		}
 	} else {
 		fmt.Println()
 		logWithTimestamp(colorstring.Green, exportCmd.PrintableCmd())
 
-		xcodebuildLog, err := exportCmd.RunAndReturnOutput()
-		if err != nil {
+		xcodebuildLog, exportErr := exportCmd.RunAndReturnOutput()
+		if exportErr != nil {
 			out.XcodebuildLog = xcodebuildLog
 
 			// xcdistributionlogs
@@ -707,7 +707,7 @@ The logs directory is stored in $BITRISE_DEPLOY_DIR, and its full path
 is available in the $BITRISE_IDEDISTRIBUTION_LOGS_PATH environment variable`)
 			}
 
-			return out, fmt.Errorf("export failed, error: %s", err)
+			return out, fmt.Errorf("export failed, error: %s", exportErr)
 		}
 	}
 


### PR DESCRIPTION
### Checklist

- [x] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

Fixes the empty error in case of IPA export failure.

```
export failed, error: %!!(MISSING)s(<nil>)
```

### Changes

<!-- 
- `blahblah` is called with `hhhh` instead of `oooooo`
- `FFFFF` now returns an `error` for better error handling
- Renamed symbols in `pppppp` to increase readability
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
