### PR TITLE
Move dSYM collection after IPA export to collect all files

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,4 +1,4 @@
-format_version: 11
+format_version: "11"
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 
 workflows:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -118,6 +118,7 @@ workflows:
     - IPA_EXPORT_METHOD: auto-detect
     - IPA_EXPORT_ICLOUD_CONTAINER_ENVIRONMENT: ""
     - XCODE_OUTPUT_TOOL: xcodebuild
+    - DSYM_EXPECTED_COUNT: 3
     after_run:
     - _run
     - _check_outputs
@@ -253,14 +254,31 @@ workflows:
 
             cd $BITRISE_DSYM_DIR_PATH
 
-            if [ $(ls *.dSYM | wc -l) -eq 0 ]; then
+            if [ $(find . -name '*.dSYM' -maxdepth 1| wc -l) -eq 0 ]; then
                 echo "error, there are no files in the exported dSYM path!"
+                ls -la
                 exit 1
             fi
 
-            if [ $(ls | wc -l) -gt $(ls *.dSYM | wc -l) ]; then
+            if [ $(find . -maxdepth 1 ! -path . | wc -l) -gt $(find . -name '*.dSYM' -maxdepth 1 | wc -l) ]; then
                 echo "error, there are non-dSYM files in the exported dSYM path!"
+                ls -la
                 exit 1
+            fi
+    - script:
+        title: Check if all dSYMs are exported
+        run_if: '{{getenv "DSYM_EXPECTED_COUNT" | ne ""}}'
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+
+            cd $BITRISE_DSYM_DIR_PATH
+
+            if [ $(find . -name '*.dSYM' -maxdepth 1 | wc -l) -ne $DSYM_EXPECTED_COUNT ]; then
+              echo "error, expected dSYM count ($DSYM_EXPECTED_COUNT) doesn\'t match folder contents: "
+              ls -la
+              exit 1
             fi
 
   _check_archive_zip:


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

<!--- One sentence summary on why the change is needed. -->

Not all dSYMs are present in the `xcarchive` right after the archive phase. Files for dynamic libraries are added to the `dSYMs` folder only after the IPA export phase, so we need to collect dSYMs only at the end of the step. This is a regression caused by the reactors after v3.0, I have tested with v3.0 and that version of the step successfully collects all dSYMs from the archive.

### Changes

- Move dSYM collecting logic to the export phase of the step. This required some refactors about how we pass the xcarchive's path around since we need the reference for the whole archive (instead of its path) at the export phase.
- Add a test case to one of the E2E tests that checks the dSYM count. Asserting the exact name of the dSYMs would be too fragile (the missing dSYMs have UUID names), it could change with an Xcode update.
- Fix the other shell scripts used for testing the presence of dSYMs in the folder. Using `ls | wc -l` doesn't work for bundles (that are directories essentially), counting them this way gives an incorrect number.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
