### PR TITLE
Fix app dSYM export when there are no frameworks

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -99,6 +99,7 @@ workflows:
     - IPA_EXPORT_METHOD: development
     - IPA_EXPORT_ICLOUD_CONTAINER_ENVIRONMENT: ""
     - XCODE_OUTPUT_TOOL: xcodebuild
+    - DSYM_EXPECTED_COUNT: 1 # Only 1 framework dSYM
     after_run:
     - _run
     - _check_outputs
@@ -210,6 +211,7 @@ workflows:
         inputs:
         - content: envman add --key ARTIFACT_NAME --value $BITRISE_SCHEME
     - path::./:
+        title: Execute step
         inputs:
         - project_path: "./_tmp/$BITRISE_PROJECT_PATH"
         - scheme: $BITRISE_SCHEME

--- a/main.go
+++ b/main.go
@@ -876,12 +876,12 @@ func (s XcodeArchiveStep) ExportOutput(opts ExportOpts) error {
 				return fmt.Errorf("failed to create tmp dir, error: %s", err)
 			}
 
-			if len(frameworkDSYMPaths) > 0 {
+			if len(appDSYMPaths) > 0 {
 				if err := exportDSYMs(dsymDir, appDSYMPaths); err != nil {
 					return fmt.Errorf("failed to export dSYMs: %v", err)
 				}
 			} else {
-				log.Warnf("no app dsyms found")
+				log.Warnf("No app dSYMs found to export")
 			}
 
 			if opts.ExportAllDsyms && len(frameworkDSYMPaths) > 0 {


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

In #240 the dSYM export was refactored, but there is an error in one of the if statements. This causes a bug: when there are no framework dSYMs then the main app dSYM is not exported (#241)

### Changes

- Fix program flow
- Improve E2E tests a bit

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
