### PR TITLE
Remove stack constraints from E2E tests

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -14,16 +14,8 @@ app:
   - BITFALL_APPLE_PROVISIONING_PROFILE_URL_LIST: $BITFALL_APPLE_PROVISIONING_PROFILE_URL_LIST
 
 workflows:
-  test_app_clip:
-    steps:
-    - bitrise-run:
-        run_if: |-
-          {{ enveq "BITRISEIO_STACK_ID" "osx-xcode-12.5.x" }}
-        inputs:
-        - workflow_id: utility_test_app_clip
-        - bitrise_config_path: ./e2e/bitrise.yml
 
-  utility_test_app_clip:
+  test_app_clip:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/Fruta
     - TEST_APP_BRANCH: xcode-12-gm
@@ -42,15 +34,6 @@ workflows:
     - _check_exported_artifacts
 
   test_catalyst:
-    steps:
-    - bitrise-run:
-        run_if: |-
-          {{ enveq "BITRISEIO_STACK_ID" "osx-xcode-12.5.x" }}
-        inputs:
-        - workflow_id: utility_test_catalyst
-        - bitrise_config_path: ./e2e/bitrise.yml
-
-  utility_test_catalyst:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-io/CatalystSample.git
     - TEST_APP_BRANCH: master


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires NO [version update](https://semver.org/)

### Context

Previously this was used to skip certain tests on stacks < Xcode 12. We don't run tests on Xcode 11 anymore.

### Changes

Run E2E tests unconditionally.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
