### PR TITLE
Explain better why -showBuildSettings command takes a lot of time.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.1
 	github.com/bitrise-io/go-utils v1.0.1
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2
-	github.com/bitrise-io/go-xcode v1.0.2
-	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9
+	github.com/bitrise-io/go-xcode v1.0.4-0.20220301092540-dd63ac6ccd79
+	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9.0.20220301104417-73d05afd5b92
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.1
 	github.com/bitrise-io/go-utils v1.0.1
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2
-	github.com/bitrise-io/go-xcode v1.0.4-0.20220301145048-ee9aaaeefd0d
+	github.com/bitrise-io/go-xcode v1.0.4-0.20220303145035-32b2519cff40
 	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.1
 	github.com/bitrise-io/go-utils v1.0.1
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2
-	github.com/bitrise-io/go-xcode v1.0.5-0.20220303155724-31843c88e3b2
+	github.com/bitrise-io/go-xcode v1.0.5-0.20220303165703-cd3a6caa0c7a
 	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.1
 	github.com/bitrise-io/go-utils v1.0.1
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2
-	github.com/bitrise-io/go-xcode v1.0.5-0.20220304085114-810880454edb
+	github.com/bitrise-io/go-xcode v1.0.5
 	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bitrise-io/go-utils v1.0.1
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2
 	github.com/bitrise-io/go-xcode v1.0.4-0.20220301092540-dd63ac6ccd79
-	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9.0.20220301104417-73d05afd5b92
+	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9.0.20220301143542-2f33973ad10c
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.1
 	github.com/bitrise-io/go-utils v1.0.1
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2
-	github.com/bitrise-io/go-xcode v1.0.5-0.20220303150513-eacbb0ea3534
+	github.com/bitrise-io/go-xcode v1.0.5-0.20220303155724-31843c88e3b2
 	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.1
 	github.com/bitrise-io/go-utils v1.0.1
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2
-	github.com/bitrise-io/go-xcode v1.0.5-0.20220303165703-cd3a6caa0c7a
+	github.com/bitrise-io/go-xcode v1.0.5-0.20220304085114-810880454edb
 	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.7.0

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.1
 	github.com/bitrise-io/go-utils v1.0.1
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2
-	github.com/bitrise-io/go-xcode v1.0.4-0.20220301092540-dd63ac6ccd79
-	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9.0.20220301143542-2f33973ad10c
+	github.com/bitrise-io/go-xcode v1.0.4-0.20220301145048-ee9aaaeefd0d
+	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.1
 	github.com/bitrise-io/go-utils v1.0.1
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2
-	github.com/bitrise-io/go-xcode v1.0.4-0.20220303145035-32b2519cff40
+	github.com/bitrise-io/go-xcode v1.0.5-0.20220303150513-eacbb0ea3534
 	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.1/go.mod h1:sy+Ir1X8P3tAAx/qU/r+h
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2 h1:w3fwgLLmxMOpYNa6W5aLtJZE8M8+qGE5VPOcr+st59c=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2/go.mod h1:sy+Ir1X8P3tAAx/qU/r+hqDjHDcrMjIzDEvId1wqNc4=
 github.com/bitrise-io/go-xcode v1.0.1/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
+github.com/bitrise-io/go-xcode v1.0.4 h1:9i3VlaUX46LqdDKnjFd8aYRmzqUKp9wFKEoBYhNWfao=
+github.com/bitrise-io/go-xcode v1.0.4/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/go-xcode v1.0.5-0.20220303150513-eacbb0ea3534 h1:yK80oQf8EB3Bp3JFQ6rigrt+zSSobdzz9uIWqtA47sE=
 github.com/bitrise-io/go-xcode v1.0.5-0.20220303150513-eacbb0ea3534/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/go-xcode v1.0.5-0.20220303155724-31843c88e3b2 h1:/koeN8V5K5YEn2zdLA/EiaK0f5KG208DGiljheX9hjA=
@@ -18,6 +20,8 @@ github.com/bitrise-io/go-xcode v1.0.5-0.20220303165703-cd3a6caa0c7a h1:IRwm19YLJ
 github.com/bitrise-io/go-xcode v1.0.5-0.20220303165703-cd3a6caa0c7a/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/go-xcode v1.0.5-0.20220304085114-810880454edb h1:G4EpFGZSnBEaSjviYhRkgcs4W009rqTWV3RBu+78paI=
 github.com/bitrise-io/go-xcode v1.0.5-0.20220304085114-810880454edb/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
+github.com/bitrise-io/go-xcode v1.0.5 h1:T0I1ED5oDifbO57VSNxhLh+8T9vcdGt+5U/kOrzFKeQ=
+github.com/bitrise-io/go-xcode v1.0.5/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9 h1:zBb8U+i6LrZXdTSh+FrXhb/ivw/ghnLVmhU5mjQIOSM=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9/go.mod h1:6YbvyYwZgSTt96CQSQ6QlrkcRiv3ssX8zLijh2TPnbU=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8 h1:kmvU8AxrNTxXsVPKepBHD8W+eCVmeaKyTkRuUJB2K38=

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/bitrise-io/go-xcode v1.0.5-0.20220303150513-eacbb0ea3534 h1:yK80oQf8E
 github.com/bitrise-io/go-xcode v1.0.5-0.20220303150513-eacbb0ea3534/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/go-xcode v1.0.5-0.20220303155724-31843c88e3b2 h1:/koeN8V5K5YEn2zdLA/EiaK0f5KG208DGiljheX9hjA=
 github.com/bitrise-io/go-xcode v1.0.5-0.20220303155724-31843c88e3b2/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
+github.com/bitrise-io/go-xcode v1.0.5-0.20220303165703-cd3a6caa0c7a h1:IRwm19YLJBh0Mf+cJB5n+gUT1CEG2RHwJFVmV4tc+xM=
+github.com/bitrise-io/go-xcode v1.0.5-0.20220303165703-cd3a6caa0c7a/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9 h1:zBb8U+i6LrZXdTSh+FrXhb/ivw/ghnLVmhU5mjQIOSM=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9/go.mod h1:6YbvyYwZgSTt96CQSQ6QlrkcRiv3ssX8zLijh2TPnbU=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8 h1:kmvU8AxrNTxXsVPKepBHD8W+eCVmeaKyTkRuUJB2K38=

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2 h1:w3fwgLLmxMOpYNa6W5aLtJZE8M8+
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2/go.mod h1:sy+Ir1X8P3tAAx/qU/r+hqDjHDcrMjIzDEvId1wqNc4=
 github.com/bitrise-io/go-xcode v1.0.4-0.20220301092540-dd63ac6ccd79 h1:bF476SdO3cLKzoMEg1lkVyU1Mfa6qyyrrOfBcK8o4Wk=
 github.com/bitrise-io/go-xcode v1.0.4-0.20220301092540-dd63ac6ccd79/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
-github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9.0.20220301104417-73d05afd5b92 h1:gcHhhn6Oh1C2ln3zqADq8aUkxwX5SmLOCOuiM9uHtEA=
-github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9.0.20220301104417-73d05afd5b92/go.mod h1:ItqAPPHby0dls0rM2BAwpaD9V1MMwNn3ei6O1d/da/o=
+github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9.0.20220301143542-2f33973ad10c h1:6uqLAsLWCCTAvN5MYEkXgobMbMgTFMuKLouV+L0ILmI=
+github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9.0.20220301143542-2f33973ad10c/go.mod h1:ItqAPPHby0dls0rM2BAwpaD9V1MMwNn3ei6O1d/da/o=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8 h1:kmvU8AxrNTxXsVPKepBHD8W+eCVmeaKyTkRuUJB2K38=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8/go.mod h1:UiXKNs0essbC14a2TvGlnUKo9isP9m4guPrp8KJHJpU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/bitrise-io/go-xcode v1.0.5-0.20220303155724-31843c88e3b2 h1:/koeN8V5K
 github.com/bitrise-io/go-xcode v1.0.5-0.20220303155724-31843c88e3b2/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/go-xcode v1.0.5-0.20220303165703-cd3a6caa0c7a h1:IRwm19YLJBh0Mf+cJB5n+gUT1CEG2RHwJFVmV4tc+xM=
 github.com/bitrise-io/go-xcode v1.0.5-0.20220303165703-cd3a6caa0c7a/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
+github.com/bitrise-io/go-xcode v1.0.5-0.20220304085114-810880454edb h1:G4EpFGZSnBEaSjviYhRkgcs4W009rqTWV3RBu+78paI=
+github.com/bitrise-io/go-xcode v1.0.5-0.20220304085114-810880454edb/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9 h1:zBb8U+i6LrZXdTSh+FrXhb/ivw/ghnLVmhU5mjQIOSM=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9/go.mod h1:6YbvyYwZgSTt96CQSQ6QlrkcRiv3ssX8zLijh2TPnbU=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8 h1:kmvU8AxrNTxXsVPKepBHD8W+eCVmeaKyTkRuUJB2K38=

--- a/go.sum
+++ b/go.sum
@@ -9,11 +9,10 @@ github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.1/go.mod h1:sy+Ir1X8P3tAAx/qU/r+hqDjHDcrMjIzDEvId1wqNc4=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2 h1:w3fwgLLmxMOpYNa6W5aLtJZE8M8+qGE5VPOcr+st59c=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2/go.mod h1:sy+Ir1X8P3tAAx/qU/r+hqDjHDcrMjIzDEvId1wqNc4=
-github.com/bitrise-io/go-xcode v1.0.1/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
-github.com/bitrise-io/go-xcode v1.0.2 h1:Uv/cBOJ/qZpitjOpyS8orafee3wk66OwvRTbqA2fr+4=
-github.com/bitrise-io/go-xcode v1.0.2/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
-github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9 h1:zBb8U+i6LrZXdTSh+FrXhb/ivw/ghnLVmhU5mjQIOSM=
-github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9/go.mod h1:6YbvyYwZgSTt96CQSQ6QlrkcRiv3ssX8zLijh2TPnbU=
+github.com/bitrise-io/go-xcode v1.0.4-0.20220301092540-dd63ac6ccd79 h1:bF476SdO3cLKzoMEg1lkVyU1Mfa6qyyrrOfBcK8o4Wk=
+github.com/bitrise-io/go-xcode v1.0.4-0.20220301092540-dd63ac6ccd79/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
+github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9.0.20220301104417-73d05afd5b92 h1:gcHhhn6Oh1C2ln3zqADq8aUkxwX5SmLOCOuiM9uHtEA=
+github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9.0.20220301104417-73d05afd5b92/go.mod h1:ItqAPPHby0dls0rM2BAwpaD9V1MMwNn3ei6O1d/da/o=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8 h1:kmvU8AxrNTxXsVPKepBHD8W+eCVmeaKyTkRuUJB2K38=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8/go.mod h1:UiXKNs0essbC14a2TvGlnUKo9isP9m4guPrp8KJHJpU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -9,10 +9,13 @@ github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.1/go.mod h1:sy+Ir1X8P3tAAx/qU/r+hqDjHDcrMjIzDEvId1wqNc4=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2 h1:w3fwgLLmxMOpYNa6W5aLtJZE8M8+qGE5VPOcr+st59c=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2/go.mod h1:sy+Ir1X8P3tAAx/qU/r+hqDjHDcrMjIzDEvId1wqNc4=
-github.com/bitrise-io/go-xcode v1.0.4-0.20220301092540-dd63ac6ccd79 h1:bF476SdO3cLKzoMEg1lkVyU1Mfa6qyyrrOfBcK8o4Wk=
-github.com/bitrise-io/go-xcode v1.0.4-0.20220301092540-dd63ac6ccd79/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
-github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9.0.20220301143542-2f33973ad10c h1:6uqLAsLWCCTAvN5MYEkXgobMbMgTFMuKLouV+L0ILmI=
-github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9.0.20220301143542-2f33973ad10c/go.mod h1:ItqAPPHby0dls0rM2BAwpaD9V1MMwNn3ei6O1d/da/o=
+github.com/bitrise-io/go-xcode v1.0.1/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
+github.com/bitrise-io/go-xcode v1.0.4-0.20220301144534-869c23c7417c h1:JFy0RKy8K0efNvwgUE0tC5VJQUauJjoSEhAPA/v89gM=
+github.com/bitrise-io/go-xcode v1.0.4-0.20220301144534-869c23c7417c/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
+github.com/bitrise-io/go-xcode v1.0.4-0.20220301145048-ee9aaaeefd0d h1:eD40hFcnLu4mQPt4pDiGtUp3p3+pSr0iSwf1hIORRjs=
+github.com/bitrise-io/go-xcode v1.0.4-0.20220301145048-ee9aaaeefd0d/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
+github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9 h1:zBb8U+i6LrZXdTSh+FrXhb/ivw/ghnLVmhU5mjQIOSM=
+github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9/go.mod h1:6YbvyYwZgSTt96CQSQ6QlrkcRiv3ssX8zLijh2TPnbU=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8 h1:kmvU8AxrNTxXsVPKepBHD8W+eCVmeaKyTkRuUJB2K38=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8/go.mod h1:UiXKNs0essbC14a2TvGlnUKo9isP9m4guPrp8KJHJpU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,10 @@ github.com/bitrise-io/go-xcode v1.0.4-0.20220301144534-869c23c7417c h1:JFy0RKy8K
 github.com/bitrise-io/go-xcode v1.0.4-0.20220301144534-869c23c7417c/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/go-xcode v1.0.4-0.20220301145048-ee9aaaeefd0d h1:eD40hFcnLu4mQPt4pDiGtUp3p3+pSr0iSwf1hIORRjs=
 github.com/bitrise-io/go-xcode v1.0.4-0.20220301145048-ee9aaaeefd0d/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
+github.com/bitrise-io/go-xcode v1.0.4-0.20220303145035-32b2519cff40 h1:aYlfdtxcx1WN5Nw48PnsMToGxJAOWfX1LX7tih1NFrU=
+github.com/bitrise-io/go-xcode v1.0.4-0.20220303145035-32b2519cff40/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
+github.com/bitrise-io/go-xcode v1.0.4 h1:9i3VlaUX46LqdDKnjFd8aYRmzqUKp9wFKEoBYhNWfao=
+github.com/bitrise-io/go-xcode v1.0.4/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9 h1:zBb8U+i6LrZXdTSh+FrXhb/ivw/ghnLVmhU5mjQIOSM=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9/go.mod h1:6YbvyYwZgSTt96CQSQ6QlrkcRiv3ssX8zLijh2TPnbU=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8 h1:kmvU8AxrNTxXsVPKepBHD8W+eCVmeaKyTkRuUJB2K38=

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2/go.mod h1:sy+Ir1X8P3tAAx/qU/r+h
 github.com/bitrise-io/go-xcode v1.0.1/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/go-xcode v1.0.5-0.20220303150513-eacbb0ea3534 h1:yK80oQf8EB3Bp3JFQ6rigrt+zSSobdzz9uIWqtA47sE=
 github.com/bitrise-io/go-xcode v1.0.5-0.20220303150513-eacbb0ea3534/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
+github.com/bitrise-io/go-xcode v1.0.5-0.20220303155724-31843c88e3b2 h1:/koeN8V5K5YEn2zdLA/EiaK0f5KG208DGiljheX9hjA=
+github.com/bitrise-io/go-xcode v1.0.5-0.20220303155724-31843c88e3b2/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9 h1:zBb8U+i6LrZXdTSh+FrXhb/ivw/ghnLVmhU5mjQIOSM=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9/go.mod h1:6YbvyYwZgSTt96CQSQ6QlrkcRiv3ssX8zLijh2TPnbU=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8 h1:kmvU8AxrNTxXsVPKepBHD8W+eCVmeaKyTkRuUJB2K38=

--- a/go.sum
+++ b/go.sum
@@ -10,14 +10,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.1/go.mod h1:sy+Ir1X8P3tAAx/qU/r+h
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2 h1:w3fwgLLmxMOpYNa6W5aLtJZE8M8+qGE5VPOcr+st59c=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.2/go.mod h1:sy+Ir1X8P3tAAx/qU/r+hqDjHDcrMjIzDEvId1wqNc4=
 github.com/bitrise-io/go-xcode v1.0.1/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
-github.com/bitrise-io/go-xcode v1.0.4-0.20220301144534-869c23c7417c h1:JFy0RKy8K0efNvwgUE0tC5VJQUauJjoSEhAPA/v89gM=
-github.com/bitrise-io/go-xcode v1.0.4-0.20220301144534-869c23c7417c/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
-github.com/bitrise-io/go-xcode v1.0.4-0.20220301145048-ee9aaaeefd0d h1:eD40hFcnLu4mQPt4pDiGtUp3p3+pSr0iSwf1hIORRjs=
-github.com/bitrise-io/go-xcode v1.0.4-0.20220301145048-ee9aaaeefd0d/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
-github.com/bitrise-io/go-xcode v1.0.4-0.20220303145035-32b2519cff40 h1:aYlfdtxcx1WN5Nw48PnsMToGxJAOWfX1LX7tih1NFrU=
-github.com/bitrise-io/go-xcode v1.0.4-0.20220303145035-32b2519cff40/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
-github.com/bitrise-io/go-xcode v1.0.4 h1:9i3VlaUX46LqdDKnjFd8aYRmzqUKp9wFKEoBYhNWfao=
-github.com/bitrise-io/go-xcode v1.0.4/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
+github.com/bitrise-io/go-xcode v1.0.5-0.20220303150513-eacbb0ea3534 h1:yK80oQf8EB3Bp3JFQ6rigrt+zSSobdzz9uIWqtA47sE=
+github.com/bitrise-io/go-xcode v1.0.5-0.20220303150513-eacbb0ea3534/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9 h1:zBb8U+i6LrZXdTSh+FrXhb/ivw/ghnLVmhU5mjQIOSM=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9/go.mod h1:6YbvyYwZgSTt96CQSQ6QlrkcRiv3ssX8zLijh2TPnbU=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8 h1:kmvU8AxrNTxXsVPKepBHD8W+eCVmeaKyTkRuUJB2K38=

--- a/main.go
+++ b/main.go
@@ -469,7 +469,7 @@ func (s XcodeArchiveStep) xcodeArchive(opts xcodeArchiveOpts) (xcodeArchiveOutpu
 		}
 		productName, err := settings.String("PRODUCT_NAME")
 		if err != nil || productName == "" {
-			logger.Warnf("Product name not found in build settings, using scheme (%s) as artifact name", config.Scheme)
+			logger.Warnf("Product name not found in build settings, using scheme (%s) as artifact name", opts.Scheme)
 			productName = opts.Scheme
 		}
 		opts.ArtifactName = productName

--- a/main.go
+++ b/main.go
@@ -812,8 +812,9 @@ func (s XcodeArchiveStep) Run(opts RunOpts) (RunOut, error) {
 
 	logger.Println()
 	if opts.XcodeMajorVersion >= 11 {
-		// Resolve Swift package dependencies now, so running -showBuildSettings later is faster
-		resolveDepsCmd := xcodebuild.NewResolvePackagesCommandModel(opts.ProjectPath, "", "") // No scheme and configuration needed to resolve packages per project/worksapce
+		// Resolve Swift package dependencies, so running -showBuildSettings later is faster later
+		// Specifying a scheme is required for workspaces
+		resolveDepsCmd := xcodebuild.NewResolvePackagesCommandModel(opts.ProjectPath, opts.Scheme, opts.Configuration)
 		resolveDepsCmd.SetCustomOptions(customOptions)
 		if err := resolveDepsCmd.Run(); err != nil {
 			logger.Warnf("%s", err)
@@ -833,6 +834,7 @@ func (s XcodeArchiveStep) Run(opts RunOpts) (RunOut, error) {
 			logger.Warnf("Product name not found in build settings, using scheme (%s) as artifact name", opts.Scheme)
 			productName = opts.Scheme
 		}
+
 		opts.ArtifactName = productName
 	}
 	out.ArtifactName = opts.ArtifactName

--- a/main.go
+++ b/main.go
@@ -293,8 +293,9 @@ func (s XcodeArchiveStep) ProcessInputs() (Config, error) {
 
 	// Resolve Swift package dependencies now, so running -showBuildSettings later is faster
 	resolvePackagesCmd := xcodebuild.NewResolvePackagesCommandModel(config.ProjectPath).Command()
-	logger.Infof("Resolving package dependencies...")
-	logger.TDonef("%s", resolvePackagesCmd.PrintableCommandArgs())
+	logger.Println()
+	logger.Infof("Resolving package dependencies")
+	logger.TDonef("$ %s", resolvePackagesCmd.PrintableCommandArgs())
 	if err := resolvePackagesCmd.Run(); err != nil {
 		logger.Warnf("failed to resolve package dependencies: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -817,7 +817,7 @@ func (s XcodeArchiveStep) Run(opts RunOpts) (RunOut, error) {
 	logger.Println()
 	if opts.XcodeMajorVersion >= 11 {
 		// Resolve Swift package dependencies now, so running -showBuildSettings later is faster
-		if err := xcodebuild.NewResolvePackagesCommandModel(opts.ProjectPath).Run(); err != nil {
+		if err := xcodebuild.NewResolvePackagesCommandModel(opts.ProjectPath, opts.Scheme, opts.Configuration).Run(); err != nil {
 			logger.Warnf("%s", err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -451,17 +451,12 @@ type xcodeArchiveOutput struct {
 func (s XcodeArchiveStep) xcodeArchive(opts xcodeArchiveOpts) (xcodeArchiveOutput, error) {
 	out := xcodeArchiveOutput{}
 
+	logger.Println()
 	if opts.XcodeMajorVersion >= 11 {
 		// Resolve Swift package dependencies now, so running -showBuildSettings later is faster
-		resolvePackagesCmd := xcodebuild.NewResolvePackagesCommandModel(opts.ProjectPath).Command()
-		logger.Println()
-		logger.Infof("Resolving package dependencies")
-		start := time.Now()
-		logger.TDonef("$ %s", resolvePackagesCmd.PrintableCommandArgs())
-		if err := resolvePackagesCmd.Run(); err != nil {
-			logger.Warnf("failed to resolve package dependencies: %s", err)
+		if err := xcodebuild.NewResolvePackagesCommandModel(opts.ProjectPath).Run(); err != nil {
+			logger.Warnf("%s", err)
 		}
-		logger.Printf("Resolved package dependencies in %s.", time.Since(start).Round(time.Second))
 	}
 
 	if opts.ArtifactName == "" {

--- a/main.go
+++ b/main.go
@@ -291,6 +291,15 @@ func (s XcodeArchiveStep) ProcessInputs() (Config, error) {
 		}
 	}
 
+	// Resolve Swift package dependencies now, so running -showBuildSettings later is faster
+	resolvePackagesCmd := xcodebuild.NewResolvePackagesCommandModel(config.ProjectPath).Command()
+	logger.Infof("Resolving package dependencies...")
+	logger.TDonef("%s", resolvePackagesCmd.PrintableCommandArgs())
+	if err := resolvePackagesCmd.Run(); err != nil {
+		logger.Warnf("failed to resolve package dependencies: %s", err)
+	}
+	logger.TPrintf("Finished resolving package dependencies.")
+
 	if config.ArtifactName == "" {
 		cmdModel := xcodebuild.NewShowBuildSettingsCommand(config.ProjectPath)
 		cmdModel.SetScheme(config.Scheme)

--- a/main.go
+++ b/main.go
@@ -817,9 +817,9 @@ func (s XcodeArchiveStep) Run(opts RunOpts) (RunOut, error) {
 	logger.Println()
 	if opts.XcodeMajorVersion >= 11 {
 		// Resolve Swift package dependencies now, so running -showBuildSettings later is faster
-		resolveDepsCmd := xcodebuild.NewResolvePackagesCommandModel(opts.ProjectPath, opts.Scheme, opts.Configuration)
+		resolveDepsCmd := xcodebuild.NewResolvePackagesCommandModel(opts.ProjectPath, "", "") // No scheme and configuration needed to resolve packages per project/worksapce
 		resolveDepsCmd.SetCustomOptions(customOptions)
-		if err := xcodebuild.NewResolvePackagesCommandModel(opts.ProjectPath, opts.Scheme, opts.Configuration).Run(); err != nil {
+		if err := resolveDepsCmd.Run(); err != nil {
 			logger.Warnf("%s", err)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -376,11 +376,7 @@ func (s XcodeArchiveStep) createCodesignManager(config Config) (codesign.Manager
 
 // EnsureDependenciesOpts ...
 type EnsureDependenciesOpts struct {
-	XCPretty      bool
-	ProjectPath   string
-	ArtifactName  string
-	Scheme        string
-	Configuration string
+	XCPretty bool
 }
 
 // EnsureDependencies ...

--- a/main.go
+++ b/main.go
@@ -295,11 +295,12 @@ func (s XcodeArchiveStep) ProcessInputs() (Config, error) {
 	resolvePackagesCmd := xcodebuild.NewResolvePackagesCommandModel(config.ProjectPath).Command()
 	logger.Println()
 	logger.Infof("Resolving package dependencies")
+	start := time.Now()
 	logger.TDonef("$ %s", resolvePackagesCmd.PrintableCommandArgs())
 	if err := resolvePackagesCmd.Run(); err != nil {
 		logger.Warnf("failed to resolve package dependencies: %s", err)
 	}
-	logger.TPrintf("Finished resolving package dependencies.")
+	logger.Printf("Resolved package dependencies in %s.", time.Since(start).Round(time.Second))
 
 	if config.ArtifactName == "" {
 		cmdModel := xcodebuild.NewShowBuildSettingsCommand(config.ProjectPath)

--- a/vendor/github.com/bitrise-io/go-xcode/LICENSE
+++ b/vendor/github.com/bitrise-io/go-xcode/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Bitrise
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/bitrise-io/go-xcode/profileutil/util.go
+++ b/vendor/github.com/bitrise-io/go-xcode/profileutil/util.go
@@ -15,7 +15,7 @@ type ProfileType string
 const ProfileTypeIos ProfileType = "ios"
 
 // ProfileTypeMacOs ...
-const ProfileTypeMacOs ProfileType = "macos"
+const ProfileTypeMacOs ProfileType = "osx"
 
 // ProfileTypeTvOs ...
 const ProfileTypeTvOs ProfileType = "tvos"

--- a/vendor/github.com/bitrise-io/go-xcode/v2/autocodesign/projectmanager/projectmanager.go
+++ b/vendor/github.com/bitrise-io/go-xcode/v2/autocodesign/projectmanager/projectmanager.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-xcode/v2/autocodesign"
-	"github.com/bitrise-io/go-xcode/xcodebuild"
 )
 
 // Project ...
@@ -82,16 +81,6 @@ func (p Project) MainTargetBundleID() (string, error) {
 
 // GetAppLayout ...
 func (p Project) GetAppLayout(uiTestTargets bool) (autocodesign.AppLayout, error) {
-	// Resolve Swift package dependencies now, so running -showBuildSettings later is faster
-	resolvePackagesCmd := xcodebuild.NewResolvePackagesCommandModel(p.projHelper.XcProj.Path).Command()
-	log.Infof("Resolving package dependencies...")
-	log.TDonef("%s", resolvePackagesCmd.PrintableCommandArgs())
-	if err := resolvePackagesCmd.Run(); err != nil {
-		log.Warnf("failed to resolve package dependencies: %s", err)
-		return autocodesign.AppLayout{}, err
-	}
-	log.TPrintf("Finished resolving package dependencies.")
-
 	log.Printf("Configuration: %s", p.projHelper.Configuration)
 	platform, err := p.projHelper.Platform(p.projHelper.Configuration)
 	if err != nil {

--- a/vendor/github.com/bitrise-io/go-xcode/v2/autocodesign/projectmanager/projectmanager.go
+++ b/vendor/github.com/bitrise-io/go-xcode/v2/autocodesign/projectmanager/projectmanager.go
@@ -82,6 +82,7 @@ func (p Project) MainTargetBundleID() (string, error) {
 // GetAppLayout ...
 func (p Project) GetAppLayout(uiTestTargets bool) (autocodesign.AppLayout, error) {
 	log.Printf("Configuration: %s", p.projHelper.Configuration)
+
 	platform, err := p.projHelper.Platform(p.projHelper.Configuration)
 	if err != nil {
 		return autocodesign.AppLayout{}, fmt.Errorf("failed to read project platform: %s", err)

--- a/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
@@ -1,9 +1,13 @@
 package xcodebuild
 
 import (
+	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/bitrise-io/go-utils/command"
+	"github.com/bitrise-io/go-utils/errorutil"
+	"github.com/bitrise-io/go-utils/log"
 )
 
 // ResolvePackagesCommandModel is a command builder
@@ -48,4 +52,25 @@ func (m *ResolvePackagesCommandModel) cmdSlice() []string {
 func (m *ResolvePackagesCommandModel) Command() command.Model {
 	cmdSlice := m.cmdSlice()
 	return *command.NewWithStandardOuts(cmdSlice[0], cmdSlice[1:]...)
+}
+
+func (m *ResolvePackagesCommandModel) Run() error {
+	var (
+		cmd   = m.Command()
+		start = time.Now()
+	)
+
+	log.Printf("Resolving package dependencies...")
+
+	log.TDonef("$ %s", cmd.PrintableCommandArgs())
+	if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
+		if errorutil.IsExitStatusError(err) {
+			return fmt.Errorf("failed to resolve package dependencies, output: %s", out)
+		}
+		return fmt.Errorf("failed to run command: %s", err)
+	}
+
+	log.Printf("Resolved package dependencies in %s.", time.Since(start).Round(time.Second))
+
+	return nil
 }

--- a/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
@@ -42,5 +42,5 @@ func (m *ResolvePackagesCommandModel) cmdSlice() []string {
 
 func (m *ResolvePackagesCommandModel) Command() command.Model {
 	cmdSlice := m.cmdSlice()
-	return *command.New(cmdSlice[0], cmdSlice[1:]...)
+	return *command.NewWithStandardOuts(cmdSlice[0], cmdSlice[1:]...)
 }

--- a/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
@@ -1,0 +1,46 @@
+package xcodebuild
+
+import (
+	"path/filepath"
+
+	"github.com/bitrise-io/go-utils/command"
+)
+
+type ResolvePackagesCommandModel struct {
+	projectPath string
+
+	customOptions []string
+}
+
+func NewResolvePackagesCommandModel(projectPath string) *ResolvePackagesCommandModel {
+	return &ResolvePackagesCommandModel{
+		projectPath: projectPath,
+	}
+}
+
+func (m *ResolvePackagesCommandModel) SetCustomOptions(customOptions []string) *ResolvePackagesCommandModel {
+	m.customOptions = customOptions
+	return m
+}
+
+func (m *ResolvePackagesCommandModel) cmdSlice() []string {
+	slice := []string{toolName}
+
+	if m.projectPath != "" {
+		if filepath.Ext(m.projectPath) == ".xcworkspace" {
+			slice = append(slice, "-workspace", m.projectPath)
+		} else {
+			slice = append(slice, "-project", m.projectPath)
+		}
+	}
+
+	slice = append(slice, "-resolvePackageDependencies")
+	slice = append(slice, m.customOptions...)
+
+	return slice
+}
+
+func (m *ResolvePackagesCommandModel) Command() command.Model {
+	cmdSlice := m.cmdSlice()
+	return *command.New(cmdSlice[0], cmdSlice[1:]...)
+}

--- a/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
@@ -13,15 +13,19 @@ import (
 // ResolvePackagesCommandModel is a command builder
 // used to create `xcodebuild -resolvePackageDependencies` command
 type ResolvePackagesCommandModel struct {
-	projectPath string
+	projectPath   string
+	scheme        string
+	configuration string
 
 	customOptions []string
 }
 
 // NewResolvePackagesCommandModel returns a new ResolvePackagesCommandModel
-func NewResolvePackagesCommandModel(projectPath string) *ResolvePackagesCommandModel {
+func NewResolvePackagesCommandModel(projectPath, scheme, configuration string) *ResolvePackagesCommandModel {
 	return &ResolvePackagesCommandModel{
-		projectPath: projectPath,
+		projectPath:   projectPath,
+		scheme:        scheme,
+		configuration: configuration,
 	}
 }
 
@@ -42,6 +46,14 @@ func (m *ResolvePackagesCommandModel) cmdSlice() []string {
 		}
 	}
 
+	if m.scheme != "" {
+		slice = append(slice, "-scheme", m.scheme)
+	}
+
+	if m.configuration != "" {
+		slice = append(slice, "-configuration", m.configuration)
+	}
+
 	slice = append(slice, "-resolvePackageDependencies")
 	slice = append(slice, m.customOptions...)
 
@@ -49,14 +61,14 @@ func (m *ResolvePackagesCommandModel) cmdSlice() []string {
 }
 
 // Command returns the executable command
-func (m *ResolvePackagesCommandModel) Command() command.Model {
+func (m *ResolvePackagesCommandModel) command() command.Model {
 	cmdSlice := m.cmdSlice()
 	return *command.NewWithStandardOuts(cmdSlice[0], cmdSlice[1:]...)
 }
 
 func (m *ResolvePackagesCommandModel) Run() error {
 	var (
-		cmd   = m.Command()
+		cmd   = m.command()
 		start = time.Now()
 	)
 

--- a/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
@@ -6,18 +6,22 @@ import (
 	"github.com/bitrise-io/go-utils/command"
 )
 
+// ResolvePackagesCommandModel is a command builder
+// used to create `xcodebuild -resolvePackageDependencies` command
 type ResolvePackagesCommandModel struct {
 	projectPath string
 
 	customOptions []string
 }
 
+// NewResolvePackagesCommandModel returns a new ResolvePackagesCommandModel
 func NewResolvePackagesCommandModel(projectPath string) *ResolvePackagesCommandModel {
 	return &ResolvePackagesCommandModel{
 		projectPath: projectPath,
 	}
 }
 
+// SetCustomOptions sets custom options
 func (m *ResolvePackagesCommandModel) SetCustomOptions(customOptions []string) *ResolvePackagesCommandModel {
 	m.customOptions = customOptions
 	return m
@@ -40,6 +44,7 @@ func (m *ResolvePackagesCommandModel) cmdSlice() []string {
 	return slice
 }
 
+// Command returns the executable command
 func (m *ResolvePackagesCommandModel) Command() command.Model {
 	cmdSlice := m.cmdSlice()
 	return *command.NewWithStandardOuts(cmdSlice[0], cmdSlice[1:]...)

--- a/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
@@ -66,6 +66,7 @@ func (m *ResolvePackagesCommandModel) command() command.Model {
 	return *command.NewWithStandardOuts(cmdSlice[0], cmdSlice[1:]...)
 }
 
+// Run runs the command and logs elapsed time
 func (m *ResolvePackagesCommandModel) Run() error {
 	var (
 		cmd   = m.command()

--- a/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodebuild/resolve_package_deps.go
@@ -63,9 +63,9 @@ func (m *ResolvePackagesCommandModel) Run() error {
 	log.Printf("Resolving package dependencies...")
 
 	log.TDonef("$ %s", cmd.PrintableCommandArgs())
-	if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
+	if err := cmd.Run(); err != nil {
 		if errorutil.IsExitStatusError(err) {
-			return fmt.Errorf("failed to resolve package dependencies, output: %s", out)
+			return fmt.Errorf("failed to resolve package dependencies")
 		}
 		return fmt.Errorf("failed to run command: %s", err)
 	}

--- a/vendor/github.com/bitrise-io/go-xcode/xcodebuild/show_build_settings.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodebuild/show_build_settings.go
@@ -119,7 +119,8 @@ func parseBuildSettings(out string) (serialized.Object, error) {
 // RunAndReturnSettings ...
 func (c ShowBuildSettingsCommandModel) RunAndReturnSettings() (serialized.Object, error) {
 	cmd := c.Command()
-	log.TDonef("%s", cmd.PrintableCommandArgs())
+	log.TPrintf("Reading build settings:")
+	log.TDonef("$ %s", cmd.PrintableCommandArgs())
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		if errorutil.IsExitStatusError(err) {

--- a/vendor/github.com/bitrise-io/go-xcode/xcodebuild/show_build_settings.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodebuild/show_build_settings.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/errorutil"
+	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-io/go-xcode/xcodeproject/serialized"
 )
 
@@ -118,6 +119,7 @@ func parseBuildSettings(out string) (serialized.Object, error) {
 // RunAndReturnSettings ...
 func (c ShowBuildSettingsCommandModel) RunAndReturnSettings() (serialized.Object, error) {
 	cmd := c.Command()
+	log.TDonef("%s", cmd.PrintableCommandArgs())
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		if errorutil.IsExitStatusError(err) {
@@ -125,6 +127,7 @@ func (c ShowBuildSettingsCommandModel) RunAndReturnSettings() (serialized.Object
 		}
 		return nil, fmt.Errorf("failed to run command %s: %s", cmd.PrintableCommandArgs(), err)
 	}
+	log.TPrintf("Finished reading target settings.")
 
 	return parseBuildSettings(out)
 }

--- a/vendor/github.com/bitrise-io/go-xcode/xcodebuild/show_build_settings.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodebuild/show_build_settings.go
@@ -119,17 +119,22 @@ func parseBuildSettings(out string) (serialized.Object, error) {
 
 // RunAndReturnSettings ...
 func (c ShowBuildSettingsCommandModel) RunAndReturnSettings() (serialized.Object, error) {
-	cmd := c.Command()
-	log.Printf("Reading build settings:")
-	start := time.Now()
+	var (
+		cmd   = c.Command()
+		start = time.Now()
+	)
+
+	log.Printf("Reading build settings...")
+
 	log.TDonef("$ %s", cmd.PrintableCommandArgs())
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		if errorutil.IsExitStatusError(err) {
-			return nil, fmt.Errorf("%s command failed: output: %s", cmd.PrintableCommandArgs(), out)
+			return nil, fmt.Errorf("%s command failed, output: %s", cmd.PrintableCommandArgs(), out)
 		}
 		return nil, fmt.Errorf("failed to run command %s: %s", cmd.PrintableCommandArgs(), err)
 	}
+
 	log.Printf("Read target settings in %s.", time.Since(start).Round(time.Second))
 
 	return parseBuildSettings(out)

--- a/vendor/github.com/bitrise-io/go-xcode/xcodebuild/show_build_settings.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodebuild/show_build_settings.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/bitrise-io/go-utils/command"
 	"github.com/bitrise-io/go-utils/errorutil"
@@ -119,7 +120,8 @@ func parseBuildSettings(out string) (serialized.Object, error) {
 // RunAndReturnSettings ...
 func (c ShowBuildSettingsCommandModel) RunAndReturnSettings() (serialized.Object, error) {
 	cmd := c.Command()
-	log.TPrintf("Reading build settings:")
+	log.Printf("Reading build settings:")
+	start := time.Now()
 	log.TDonef("$ %s", cmd.PrintableCommandArgs())
 	out, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
@@ -128,7 +130,7 @@ func (c ShowBuildSettingsCommandModel) RunAndReturnSettings() (serialized.Object
 		}
 		return nil, fmt.Errorf("failed to run command %s: %s", cmd.PrintableCommandArgs(), err)
 	}
-	log.TPrintf("Finished reading target settings.")
+	log.Printf("Read target settings in %s.", time.Since(start).Round(time.Second))
 
 	return parseBuildSettings(out)
 }

--- a/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj/target.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj/target.go
@@ -17,6 +17,8 @@ const (
 	LegacyTargetType    TargetType = "PBXLegacyTarget"
 )
 
+const appClipProductType = "com.apple.product-type.application.on-demand-install-capable"
+
 // Target ...
 type Target struct {
 	Type                   TargetType
@@ -103,6 +105,22 @@ func (t Target) IsTestProduct() bool {
 // IsUITestProduct ...
 func (t Target) IsUITestProduct() bool {
 	return filepath.Ext(t.ProductType) == ".ui-testing"
+}
+
+func (t Target) isAppClipProduct() bool {
+	return t.ProductType == appClipProductType
+}
+
+// CanExportAppClip ...
+func (t Target) CanExportAppClip() bool {
+	deps := t.DependentTargets()
+	for _, target := range deps {
+		if target.isAppClipProduct() {
+			return true
+		}
+	}
+
+	return false
 }
 
 func parseTarget(id string, objects serialized.Object) (Target, error) {

--- a/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcscheme/xcscheme.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcscheme/xcscheme.go
@@ -25,6 +25,10 @@ func (r BuildableReference) IsAppReference() bool {
 	return filepath.Ext(r.BuildableName) == ".app"
 }
 
+func (r BuildableReference) isTestProduct() bool {
+	return filepath.Ext(r.BuildableName) == ".xctest"
+}
+
 // ReferencedContainerAbsPath ...
 func (r BuildableReference) ReferencedContainerAbsPath(schemeContainerDir string) (string, error) {
 	s := strings.Split(r.ReferencedContainer, ":")
@@ -60,6 +64,10 @@ type BuildAction struct {
 type TestableReference struct {
 	Skipped            string `xml:"skipped,attr"`
 	BuildableReference BuildableReference
+}
+
+func (r TestableReference) isTestable() bool {
+	return r.Skipped == "NO" && r.BuildableReference.isTestProduct()
 }
 
 // MacroExpansion ...
@@ -229,4 +237,15 @@ func (s Scheme) AppBuildActionEntry() (BuildActionEntry, bool) {
 	}
 
 	return entry, (entry.BuildableReference.BlueprintIdentifier != "")
+}
+
+// IsTestable returns true if Test is a valid action
+func (s Scheme) IsTestable() bool {
+	for _, testEntry := range s.TestAction.Testables {
+		if testEntry.isTestable() {
+			return true
+		}
+	}
+
+	return false
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -54,7 +54,7 @@ github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj
 github.com/bitrise-io/go-xcode/xcodeproject/xcscheme
 github.com/bitrise-io/go-xcode/xcodeproject/xcworkspace
 github.com/bitrise-io/go-xcode/xcpretty
-# github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9.0.20220301104417-73d05afd5b92
+# github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9.0.20220301143542-2f33973ad10c
 ## explicit
 github.com/bitrise-io/go-xcode/v2/autocodesign
 github.com/bitrise-io/go-xcode/v2/autocodesign/certdownloader

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -34,7 +34,7 @@ github.com/bitrise-io/go-utils/v2/env
 github.com/bitrise-io/go-utils/v2/fileutil
 github.com/bitrise-io/go-utils/v2/log
 github.com/bitrise-io/go-utils/v2/pathutil
-# github.com/bitrise-io/go-xcode v1.0.5-0.20220303150513-eacbb0ea3534
+# github.com/bitrise-io/go-xcode v1.0.5-0.20220303155724-31843c88e3b2
 ## explicit
 github.com/bitrise-io/go-xcode/appleauth
 github.com/bitrise-io/go-xcode/certificateutil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -34,7 +34,7 @@ github.com/bitrise-io/go-utils/v2/env
 github.com/bitrise-io/go-utils/v2/fileutil
 github.com/bitrise-io/go-utils/v2/log
 github.com/bitrise-io/go-utils/v2/pathutil
-# github.com/bitrise-io/go-xcode v1.0.4-0.20220301145048-ee9aaaeefd0d
+# github.com/bitrise-io/go-xcode v1.0.4-0.20220303145035-32b2519cff40
 ## explicit
 github.com/bitrise-io/go-xcode/appleauth
 github.com/bitrise-io/go-xcode/certificateutil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -34,7 +34,7 @@ github.com/bitrise-io/go-utils/v2/env
 github.com/bitrise-io/go-utils/v2/fileutil
 github.com/bitrise-io/go-utils/v2/log
 github.com/bitrise-io/go-utils/v2/pathutil
-# github.com/bitrise-io/go-xcode v1.0.5-0.20220304085114-810880454edb
+# github.com/bitrise-io/go-xcode v1.0.5
 ## explicit
 github.com/bitrise-io/go-xcode/appleauth
 github.com/bitrise-io/go-xcode/certificateutil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -34,7 +34,7 @@ github.com/bitrise-io/go-utils/v2/env
 github.com/bitrise-io/go-utils/v2/fileutil
 github.com/bitrise-io/go-utils/v2/log
 github.com/bitrise-io/go-utils/v2/pathutil
-# github.com/bitrise-io/go-xcode v1.0.5-0.20220303165703-cd3a6caa0c7a
+# github.com/bitrise-io/go-xcode v1.0.5-0.20220304085114-810880454edb
 ## explicit
 github.com/bitrise-io/go-xcode/appleauth
 github.com/bitrise-io/go-xcode/certificateutil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -34,7 +34,7 @@ github.com/bitrise-io/go-utils/v2/env
 github.com/bitrise-io/go-utils/v2/fileutil
 github.com/bitrise-io/go-utils/v2/log
 github.com/bitrise-io/go-utils/v2/pathutil
-# github.com/bitrise-io/go-xcode v1.0.4-0.20220301092540-dd63ac6ccd79
+# github.com/bitrise-io/go-xcode v1.0.4-0.20220301145048-ee9aaaeefd0d
 ## explicit
 github.com/bitrise-io/go-xcode/appleauth
 github.com/bitrise-io/go-xcode/certificateutil
@@ -54,7 +54,7 @@ github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj
 github.com/bitrise-io/go-xcode/xcodeproject/xcscheme
 github.com/bitrise-io/go-xcode/xcodeproject/xcworkspace
 github.com/bitrise-io/go-xcode/xcpretty
-# github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9.0.20220301143542-2f33973ad10c
+# github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9
 ## explicit
 github.com/bitrise-io/go-xcode/v2/autocodesign
 github.com/bitrise-io/go-xcode/v2/autocodesign/certdownloader

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -34,7 +34,7 @@ github.com/bitrise-io/go-utils/v2/env
 github.com/bitrise-io/go-utils/v2/fileutil
 github.com/bitrise-io/go-utils/v2/log
 github.com/bitrise-io/go-utils/v2/pathutil
-# github.com/bitrise-io/go-xcode v1.0.4-0.20220303145035-32b2519cff40
+# github.com/bitrise-io/go-xcode v1.0.5-0.20220303150513-eacbb0ea3534
 ## explicit
 github.com/bitrise-io/go-xcode/appleauth
 github.com/bitrise-io/go-xcode/certificateutil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -34,7 +34,7 @@ github.com/bitrise-io/go-utils/v2/env
 github.com/bitrise-io/go-utils/v2/fileutil
 github.com/bitrise-io/go-utils/v2/log
 github.com/bitrise-io/go-utils/v2/pathutil
-# github.com/bitrise-io/go-xcode v1.0.5-0.20220303155724-31843c88e3b2
+# github.com/bitrise-io/go-xcode v1.0.5-0.20220303165703-cd3a6caa0c7a
 ## explicit
 github.com/bitrise-io/go-xcode/appleauth
 github.com/bitrise-io/go-xcode/certificateutil

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -34,7 +34,7 @@ github.com/bitrise-io/go-utils/v2/env
 github.com/bitrise-io/go-utils/v2/fileutil
 github.com/bitrise-io/go-utils/v2/log
 github.com/bitrise-io/go-utils/v2/pathutil
-# github.com/bitrise-io/go-xcode v1.0.2
+# github.com/bitrise-io/go-xcode v1.0.4-0.20220301092540-dd63ac6ccd79
 ## explicit
 github.com/bitrise-io/go-xcode/appleauth
 github.com/bitrise-io/go-xcode/certificateutil
@@ -54,7 +54,7 @@ github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj
 github.com/bitrise-io/go-xcode/xcodeproject/xcscheme
 github.com/bitrise-io/go-xcode/xcodeproject/xcworkspace
 github.com/bitrise-io/go-xcode/xcpretty
-# github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9
+# github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.9.0.20220301104417-73d05afd5b92
 ## explicit
 github.com/bitrise-io/go-xcode/v2/autocodesign
 github.com/bitrise-io/go-xcode/v2/autocodesign/certdownloader


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

Improves the perceived slowness of the manage code signing phase.


Resolves: https://bitrise.atlassian.net/browse/STEP-1834
### Changes

* moved resolving artifact name from the Conifg phase to the Run phase, so it is after resolving pacakge deps
* Explicitely run -resolvePackageDependencies command to fetch Swift Packages
* Adds timestamps and log -showBuildSettings commands

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
