### PR TITLE
Plang 2392 input parsing errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bitrise-io/go-utils v1.0.2
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.11
 	github.com/bitrise-io/go-xcode v1.0.9
-	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.20
+	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.22
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.7.1
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bitrise-io/go-utils v1.0.2
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.11
 	github.com/bitrise-io/go-xcode v1.0.9
-	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.22
+	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.23
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.7.1
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e // indirect

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.11 h1:IacLMHL7hhgVcqtx15Bysq738P8
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.11/go.mod h1:SJqGxzwjIAx2LVQxNGS4taN7X//eDPJLrFxJ1MpOuyA=
 github.com/bitrise-io/go-xcode v1.0.9 h1:+sbqOYidQ+aiFfCTDpf2LdGSQEM5RfbtDsiG27zJG+s=
 github.com/bitrise-io/go-xcode v1.0.9/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
-github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.20 h1:MIH3eGNcAsc5VBACiU+EFcmUfqCyT6/fMSi2UjYR9+s=
-github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.20/go.mod h1:8WBcRgrVXY8tzR7NcjE4fw6WguOIfB3YcC7ZTcQYUEY=
+github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.22 h1:zsuwu0xQZfD9DsKaRNLQVy/Q6IPLqgwIiZQlvb73Y5c=
+github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.22/go.mod h1:8WBcRgrVXY8tzR7NcjE4fw6WguOIfB3YcC7ZTcQYUEY=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8 h1:kmvU8AxrNTxXsVPKepBHD8W+eCVmeaKyTkRuUJB2K38=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8/go.mod h1:UiXKNs0essbC14a2TvGlnUKo9isP9m4guPrp8KJHJpU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.11 h1:IacLMHL7hhgVcqtx15Bysq738P8
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.11/go.mod h1:SJqGxzwjIAx2LVQxNGS4taN7X//eDPJLrFxJ1MpOuyA=
 github.com/bitrise-io/go-xcode v1.0.9 h1:+sbqOYidQ+aiFfCTDpf2LdGSQEM5RfbtDsiG27zJG+s=
 github.com/bitrise-io/go-xcode v1.0.9/go.mod h1:Y0Wu2dXm0MilJ/4D3+gPHaNMlUcP+1DjIPoLPykq7wY=
-github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.22 h1:zsuwu0xQZfD9DsKaRNLQVy/Q6IPLqgwIiZQlvb73Y5c=
-github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.22/go.mod h1:8WBcRgrVXY8tzR7NcjE4fw6WguOIfB3YcC7ZTcQYUEY=
+github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.23 h1:1RXlcfA0w0IOhlVVza2Mo3QPChLnGQmIfEppA3CJmd8=
+github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.23/go.mod h1:8WBcRgrVXY8tzR7NcjE4fw6WguOIfB3YcC7ZTcQYUEY=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8 h1:kmvU8AxrNTxXsVPKepBHD8W+eCVmeaKyTkRuUJB2K38=
 github.com/bitrise-io/pkcs12 v0.0.0-20211108084543-e52728e011c8/go.mod h1:UiXKNs0essbC14a2TvGlnUKo9isP9m4guPrp8KJHJpU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/step/errors_test.go
+++ b/step/errors_test.go
@@ -36,3 +36,76 @@ func TestNew(t *testing.T) {
 		})
 	}
 }
+
+func Test_findXcodebuildErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		out  string
+		want []string
+	}{
+		{
+			name: "Regular error",
+			out:  `error: exportArchive: "code-sign-test.app" requires a provisioning profile.`,
+			want: []string{`error: exportArchive: "code-sign-test.app" requires a provisioning profile.`},
+		},
+		{
+			name: "xcodebuild error",
+			out: `xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.
+        Reason: This scheme builds an embedded Apple Watch app. watchOS 9.0 must be installed in order to archive the scheme
+        Recovery suggestion: watchOS 9.0 is not installed. To use with Xcode, first download and install the platform`,
+			want: []string{`xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.
+Reason: This scheme builds an embedded Apple Watch app. watchOS 9.0 must be installed in order to archive the scheme
+Recovery suggestion: watchOS 9.0 is not installed. To use with Xcode, first download and install the platform`},
+		},
+		{
+			name: "NSError",
+			out:  `Error Domain=IDEProvisioningErrorDomain Code=9 ""code-sign-test.app" requires a provisioning profile." UserInfo={IDEDistributionIssueSeverity=3, NSLocalizedDescription="code-sign-test.app" requires a provisioning profile., NSLocalizedRecoverySuggestion=Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.}`,
+			want: []string{`"code-sign-test.app" requires a provisioning profile. Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.`},
+		},
+		{
+			name: "Regular error and NSError pair",
+			out: `error: exportArchive: "share-extension.appex" requires a provisioning profile.
+
+Error Domain=IDEProvisioningErrorDomain Code=9 ""share-extension.appex" requires a provisioning profile." UserInfo={IDEDistributionIssueSeverity=3, NSLocalizedDescription="share-extension.appex" requires a provisioning profile., NSLocalizedRecoverySuggestion=Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.}`,
+			want: []string{`"share-extension.appex" requires a provisioning profile. Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.`},
+		},
+		{
+			name: "Extra regular error",
+			out: `error: exportArchive: "watchkit-app.app" requires a provisioning profile.
+
+Error Domain=IDEProvisioningErrorDomain Code=9 ""watchkit-app.app" requires a provisioning profile." UserInfo={IDEDistributionIssueSeverity=3, NSLocalizedDescription="watchkit-app.app" requires a provisioning profile., NSLocalizedRecoverySuggestion=Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.}
+
+error: exportArchive: "share-extension.appex" requires a provisioning profile.
+`,
+			want: []string{
+				`"watchkit-app.app" requires a provisioning profile. Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.`,
+				`error: exportArchive: "share-extension.appex" requires a provisioning profile.`,
+			},
+		},
+		{
+			name: "Regular error with NSError pair and xcodebuild error",
+			out: `error: exportArchive: "watchkit-app.app" requires a provisioning profile.
+
+Error Domain=IDEProvisioningErrorDomain Code=9 ""watchkit-app.app" requires a provisioning profile." UserInfo={IDEDistributionIssueSeverity=3, NSLocalizedDescription="watchkit-app.app" requires a provisioning profile., NSLocalizedRecoverySuggestion=Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.}
+
+xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.
+        Reason: This scheme builds an embedded Apple Watch app. watchOS 9.0 must be installed in order to archive the scheme
+        Recovery suggestion: watchOS 9.0 is not installed. To use with Xcode, first download and install the platform.
+`,
+			want: []string{
+				`"watchkit-app.app" requires a provisioning profile. Add a profile to the "provisioningProfiles" dictionary in your Export Options property list.`,
+				`xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.
+Reason: This scheme builds an embedded Apple Watch app. watchOS 9.0 must be installed in order to archive the scheme
+Recovery suggestion: watchOS 9.0 is not installed. To use with Xcode, first download and install the platform.`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findXcodebuildErrors(tt.out); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("findXcodebuildErrors() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/step/step.go
+++ b/step/step.go
@@ -233,7 +233,7 @@ func (s XcodebuildArchiver) ProcessInputs() (Config, error) {
 	if config.CodeSigningAuthSource != codeSignSourceOff {
 		codesignManager, err := s.createCodesignManager(config)
 		if err != nil {
-			return Config{}, err
+			return Config{}, fmt.Errorf("failed to prepare automatic code signing: %w", err)
 		}
 		config.CodesignManager = &codesignManager
 	}
@@ -693,7 +693,7 @@ func (s XcodebuildArchiver) createCodesignManager(config Config) (codesign.Manag
 
 	codesignConfig, err := codesign.ParseConfig(codesignInputs, s.cmdFactory)
 	if err != nil {
-		return codesign.Manager{}, fmt.Errorf("issue with input: %s", err)
+		return codesign.Manager{}, err
 	}
 
 	devPortalClientFactory := devportalclient.NewFactory(s.logger)

--- a/vendor/github.com/bitrise-io/go-xcode/v2/codesign/codesign.go
+++ b/vendor/github.com/bitrise-io/go-xcode/v2/codesign/codesign.go
@@ -210,7 +210,7 @@ func SelectConnectionCredentials(
 	if authType == APIKeyAuth {
 		if bitriseConnection == nil || bitriseConnection.APIKeyConnection == nil {
 			logger.Errorf(devportalclient.NotConnectedWarning)
-			return appleauth.Credentials{}, fmt.Errorf("API key authentication is selected in Step inputs, but Bitrise Apple Service connection is unset")
+			return appleauth.Credentials{}, fmt.Errorf("Apple Service connection via App Store Connect API key is not estabilished")
 		}
 
 		logger.Donef("Using Apple Service connection with API key.")
@@ -223,12 +223,12 @@ func SelectConnectionCredentials(
 	if authType == AppleIDAuth {
 		if bitriseConnection == nil || bitriseConnection.AppleIDConnection == nil {
 			logger.Errorf(devportalclient.NotConnectedWarning)
-			return appleauth.Credentials{}, fmt.Errorf("Apple ID authentication is selected in Step inputs, but Bitrise Apple Service connection is unset")
+			return appleauth.Credentials{}, fmt.Errorf("Apple Service connection through Apple ID is not estabilished")
 		}
 
 		session, err := bitriseConnection.AppleIDConnection.FastlaneLoginSession()
 		if err != nil {
-			return appleauth.Credentials{}, err
+			return appleauth.Credentials{}, fmt.Errorf("failed to restore Apple ID login session: %w", err)
 		}
 
 		logger.Donef("Using Apple Service connection with Apple ID.")

--- a/vendor/github.com/bitrise-io/go-xcode/v2/codesign/codesign.go
+++ b/vendor/github.com/bitrise-io/go-xcode/v2/codesign/codesign.go
@@ -209,7 +209,7 @@ func SelectConnectionCredentials(
 
 	if authType == APIKeyAuth {
 		if bitriseConnection == nil || bitriseConnection.APIKeyConnection == nil {
-			logger.Errorf(devportalclient.NotConnectedWarning)
+			logger.Warnf(devportalclient.NotConnectedWarning)
 			return appleauth.Credentials{}, fmt.Errorf("Apple Service connection via App Store Connect API key is not estabilished")
 		}
 
@@ -222,7 +222,7 @@ func SelectConnectionCredentials(
 
 	if authType == AppleIDAuth {
 		if bitriseConnection == nil || bitriseConnection.AppleIDConnection == nil {
-			logger.Errorf(devportalclient.NotConnectedWarning)
+			logger.Warnf(devportalclient.NotConnectedWarning)
 			return appleauth.Credentials{}, fmt.Errorf("Apple Service connection through Apple ID is not estabilished")
 		}
 
@@ -400,7 +400,7 @@ func (m *Manager) prepareCodeSigningWithBitrise(credentials appleauth.Credential
 		}
 
 		m.logger.Println()
-		m.logger.Errorf("Automatic code signing failed: %s", err)
+		m.logger.Warnf("Automatic code signing failed: %s", err)
 		m.logger.Println()
 		m.logger.Infof("Falling back to manually managed codesigning assets.")
 

--- a/vendor/github.com/bitrise-io/go-xcode/v2/codesign/inputparse.go
+++ b/vendor/github.com/bitrise-io/go-xcode/v2/codesign/inputparse.go
@@ -94,7 +94,7 @@ func parseConnectionOverrideConfig(keyPathOrURL stepconf.Secret, keyID, keyIssue
 		defer func(Body io.ReadCloser) {
 			err := Body.Close()
 			if err != nil {
-				logger.Errorf(err.Error())
+				logger.Warnf(err.Error())
 			}
 		}(resp.Body)
 		if resp.StatusCode != http.StatusOK {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -55,7 +55,7 @@ github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj
 github.com/bitrise-io/go-xcode/xcodeproject/xcscheme
 github.com/bitrise-io/go-xcode/xcodeproject/xcworkspace
 github.com/bitrise-io/go-xcode/xcpretty
-# github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.22
+# github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.23
 ## explicit
 github.com/bitrise-io/go-xcode/v2/autocodesign
 github.com/bitrise-io/go-xcode/v2/autocodesign/certdownloader

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -55,7 +55,7 @@ github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj
 github.com/bitrise-io/go-xcode/xcodeproject/xcscheme
 github.com/bitrise-io/go-xcode/xcodeproject/xcworkspace
 github.com/bitrise-io/go-xcode/xcpretty
-# github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.20
+# github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.22
 ## explicit
 github.com/bitrise-io/go-xcode/v2/autocodesign
 github.com/bitrise-io/go-xcode/v2/autocodesign/certdownloader


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

This PR improves automatic code signing preparation-related errors and improves parsing errors from the xcodebuild command log.

### Changes

-  Automatic code signing preparation-related errors are printed like:

```
Failed to process Step inputs:
  failed to prepare automatic code signing:
    <reason>
```
Reasons are listed in [this PR](https://github.com/bitrise-io/go-xcode/pull/186).

- xcodebuild command log parsing now knows about errors with `xcodebuild: error: ` prefix.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
