### PR TITLE
Handle errors with project path prefix

### DIFF
--- a/step/errors.go
+++ b/step/errors.go
@@ -120,11 +120,11 @@ func findXcodebuildErrors(out string) []string {
 		}
 
 		switch {
-		case strings.HasPrefix(line, "error: "):
-			errorLines = append(errorLines, line)
 		case strings.HasPrefix(line, "xcodebuild: error: "):
 			xcodebuildError = line
 			isXcodebuildError = true
+		case strings.HasPrefix(line, "error: ") || strings.Contains(line, " error: "):
+			errorLines = append(errorLines, line)
 		case strings.HasPrefix(line, "Error "):
 			if e := NewNSError(line); e != nil {
 				nserrors = append(nserrors, *e)

--- a/step/errors_test.go
+++ b/step/errors_test.go
@@ -49,11 +49,29 @@ func Test_findXcodebuildErrors(t *testing.T) {
 			want: []string{`error: exportArchive: "code-sign-test.app" requires a provisioning profile.`},
 		},
 		{
+			name: "Regular error with project path prefix",
+			out:  `./steps-xcode-archive/_tmp/code-sign-test.xcodeproj: error: No profile for team 'ASDF8V3WYL' matching 'BitriseBot-Wildcard' found: Xcode couldn't find any provisioning profiles matching 'ASDF8V3WYL/BitriseBot-Wildcard'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the Signing & Capabilities tab of the target editor. (in target 'code-sign-test' from project 'code-sign-test')`,
+			want: []string{`./steps-xcode-archive/_tmp/code-sign-test.xcodeproj: error: No profile for team 'ASDF8V3WYL' matching 'BitriseBot-Wildcard' found: Xcode couldn't find any provisioning profiles matching 'ASDF8V3WYL/BitriseBot-Wildcard'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the Signing & Capabilities tab of the target editor. (in target 'code-sign-test' from project 'code-sign-test')`},
+		},
+		{
 			name: "xcodebuild error",
 			out: `xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.
         Reason: This scheme builds an embedded Apple Watch app. watchOS 9.0 must be installed in order to archive the scheme
         Recovery suggestion: watchOS 9.0 is not installed. To use with Xcode, first download and install the platform`,
 			want: []string{`xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.
+Reason: This scheme builds an embedded Apple Watch app. watchOS 9.0 must be installed in order to archive the scheme
+Recovery suggestion: watchOS 9.0 is not installed. To use with Xcode, first download and install the platform`},
+		},
+		{
+			name: "xcodebuild error and regular error with project path prefix",
+			out: `./steps-xcode-archive/_tmp/code-sign-test.xcodeproj: error: No profile for team 'ASDF8V3WYL' matching 'BitriseBot-Wildcard' found: Xcode couldn't find any provisioning profiles matching 'ASDF8V3WYL/BitriseBot-Wildcard'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the Signing & Capabilities tab of the target editor. (in target 'code-sign-test' from project 'code-sign-test')
+
+xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.
+        Reason: This scheme builds an embedded Apple Watch app. watchOS 9.0 must be installed in order to archive the scheme
+        Recovery suggestion: watchOS 9.0 is not installed. To use with Xcode, first download and install the platform`,
+			want: []string{
+				`./steps-xcode-archive/_tmp/code-sign-test.xcodeproj: error: No profile for team 'ASDF8V3WYL' matching 'BitriseBot-Wildcard' found: Xcode couldn't find any provisioning profiles matching 'ASDF8V3WYL/BitriseBot-Wildcard'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the Signing & Capabilities tab of the target editor. (in target 'code-sign-test' from project 'code-sign-test')`,
+				`xcodebuild: error: Failed to build project code-sign-test with scheme code-sign-test.
 Reason: This scheme builds an embedded Apple Watch app. watchOS 9.0 must be installed in order to archive the scheme
 Recovery suggestion: watchOS 9.0 is not installed. To use with Xcode, first download and install the platform`},
 		},


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

This PR adds support for xcodebuild error lines with project path prefix (`./steps-xcode-archive/_tmp/code-sign-test.xcodeproj: error: No profile for team 'ASDF8V3WYL' matching 'BitriseBot-Wildcard' found: Xcode couldn't find any provisioning profiles matching 'ASDF8V3WYL/BitriseBot-Wildcard'. Install the profile (by dragging and dropping it onto Xcode's dock item) or select a different one in the Signing & Capabilities tab of the target editor. (in target 'watchkit-app' from project 'code-sign-test')`)

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

- Add support for parsing errors with project path prefix

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
