### PR TITLE
Corrected output variable and filename of raw output log

### DIFF
--- a/step/step.go
+++ b/step/step.go
@@ -643,7 +643,7 @@ func (s XcodebuildArchiver) ExportOutput(opts ExportOpts) error {
 	}
 
 	if opts.XcodebuildArchiveLog != "" {
-		xcodebuildArchiveLogPath := filepath.Join(opts.OutputDir, "xcodebuild-archive.log")
+		xcodebuildArchiveLogPath := filepath.Join(opts.OutputDir, xcodebuildArchiveLogFilename)
 		if err := cleanup(xcodebuildArchiveLogPath); err != nil {
 			return err
 		}

--- a/step/step.go
+++ b/step/step.go
@@ -51,6 +51,7 @@ const (
 	xcodebuildExportArchiveLogPathEnvKey = "BITRISE_XCODEBUILD_EXPORT_ARCHIVE_LOG_PATH"
 	bitriseIDEDistributionLogsPthEnvKey  = "BITRISE_IDEDISTRIBUTION_LOGS_PATH"
 	xcodebuildArchiveLogFilename         = "xcodebuild-archive.log"
+	xcodebuildExportArchiveLogFilename   = "xcodebuild-export-archive.log"
 
 	// Env Outputs
 	bitriseAppDirPthEnvKey    = "BITRISE_APP_DIR_PATH"
@@ -656,7 +657,7 @@ func (s XcodebuildArchiver) ExportOutput(opts ExportOpts) error {
 	}
 
 	if opts.XcodebuildExportArchiveLog != "" {
-		xcodebuildExportArchiveLogPath := filepath.Join(opts.OutputDir, "xcodebuild-export-archive.log")
+		xcodebuildExportArchiveLogPath := filepath.Join(opts.OutputDir, xcodeBuildExportArchiveLogFileName)
 		if err := cleanup(xcodebuildExportArchiveLogPath); err != nil {
 			return err
 		}
@@ -1021,8 +1022,8 @@ func (s XcodebuildArchiver) xcodeIPAExport(opts xcodeIPAExportOpts) (xcodeIPAExp
 	if exportErr != nil {
 		if useXCPretty {
 			s.logger.Warnf(fmt.Sprintf(`If you can't find the reason of the error in the log, please check the %s
-The log file is stored in $BITRISE_DEPLOY_DIR, and its full path
-is available in the $%s environment variable`, xcodebuildArchiveLogFilename, xcodebuildArchiveLogPathEnvKey))
+The log file will be stored in $BITRISE_DEPLOY_DIR, and its full path
+will be available in the $%s environment variable`, xcodebuildExportArchiveLogFilename, xcodebuildArchiveLogPathEnvKey))
 		}
 
 		// xcdistributionlogs

--- a/step/step.go
+++ b/step/step.go
@@ -50,6 +50,7 @@ const (
 	xcodebuildArchiveLogPathEnvKey       = "BITRISE_XCODEBUILD_ARCHIVE_LOG_PATH"
 	xcodebuildExportArchiveLogPathEnvKey = "BITRISE_XCODEBUILD_EXPORT_ARCHIVE_LOG_PATH"
 	bitriseIDEDistributionLogsPthEnvKey  = "BITRISE_IDEDISTRIBUTION_LOGS_PATH"
+	xcodebuildArchiveLogFilename         = "xcodebuild-archive.log"
 
 	// Env Outputs
 	bitriseAppDirPthEnvKey    = "BITRISE_APP_DIR_PATH"
@@ -867,8 +868,8 @@ and use 'Export iOS and tvOS Xcode archive' step to export an App Clip.`, opts.S
 		}
 		s.logger.Printf(stringutil.LastNLines(xcodebuildLog, 20))
 
-		s.logger.Warnf(`You can find the last couple of lines of Xcode's build log above, but the full log will be also available in the raw-xcodebuild-output.log
-The log file will be stored in $BITRISE_DEPLOY_DIR, and its full path will be available in the $BITRISE_XCODE_RAW_RESULT_TEXT_PATH environment variable.`)
+		s.logger.Warnf(fmt.Sprintf(`You can find the last couple of lines of Xcode's build log above, but the full log will be also available in the %s
+The log file will be stored in $BITRISE_DEPLOY_DIR, and its full path will be available in the $%s environment variable.`, xcodebuildArchiveLogFilename, xcodebuildArchiveLogPathEnvKey))
 	}
 	if err != nil {
 		return out, fmt.Errorf("failed to archive the project: %w", err)
@@ -1019,9 +1020,9 @@ func (s XcodebuildArchiver) xcodeIPAExport(opts xcodeIPAExportOpts) (xcodeIPAExp
 	out.XcodebuildExportArchiveLog = xcodebuildLog
 	if exportErr != nil {
 		if useXCPretty {
-			s.logger.Warnf(`If you can't find the reason of the error in the log, please check the raw-xcodebuild-output.log
+			s.logger.Warnf(fmt.Sprintf(`If you can't find the reason of the error in the log, please check the %s
 The log file is stored in $BITRISE_DEPLOY_DIR, and its full path
-is available in the $BITRISE_XCODE_RAW_RESULT_TEXT_PATH environment variable`)
+is available in the $%s environment variable`, xcodebuildArchiveLogFilename, xcodebuildArchiveLogPathEnvKey))
 		}
 
 		// xcdistributionlogs

--- a/step/step.go
+++ b/step/step.go
@@ -657,13 +657,13 @@ func (s XcodebuildArchiver) ExportOutput(opts ExportOpts) error {
 	}
 
 	if opts.XcodebuildExportArchiveLog != "" {
-		xcodebuildExportArchiveLogPath := filepath.Join(opts.OutputDir, xcodeBuildExportArchiveLogFileName)
+		xcodebuildExportArchiveLogPath := filepath.Join(opts.OutputDir, xcodebuildExportArchiveLogFilename)
 		if err := cleanup(xcodebuildExportArchiveLogPath); err != nil {
 			return err
 		}
 
 		if err := ExportOutputFileContent(s.cmdFactory, opts.XcodebuildExportArchiveLog, xcodebuildExportArchiveLogPath, xcodebuildExportArchiveLogPathEnvKey); err != nil {
-			s.logger.Warnf("Failed to export %s, error: %s", xcodebuildArchiveLogPathEnvKey, err)
+			s.logger.Warnf("Failed to export %s, error: %s", xcodebuildExportArchiveLogPathEnvKey, err)
 		} else {
 			s.logger.Donef("The xcodebuild -exportArchive log path is now available in the Environment Variable: %s (value: %s)", xcodebuildExportArchiveLogPathEnvKey, xcodebuildExportArchiveLogPath)
 		}
@@ -1023,7 +1023,7 @@ func (s XcodebuildArchiver) xcodeIPAExport(opts xcodeIPAExportOpts) (xcodeIPAExp
 		if useXCPretty {
 			s.logger.Warnf(fmt.Sprintf(`If you can't find the reason of the error in the log, please check the %s
 The log file will be stored in $BITRISE_DEPLOY_DIR, and its full path
-will be available in the $%s environment variable`, xcodebuildExportArchiveLogFilename, xcodebuildArchiveLogPathEnvKey))
+will be available in the $%s environment variable`, xcodebuildExportArchiveLogFilename, xcodebuildExportArchiveLogPathEnvKey))
 		}
 
 		// xcdistributionlogs


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Users were confused when looking for `raw-xcodebuild-output.log` in their build artifacts.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

Updated the messages to indicate the correct env var and file name

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

The expected file was not referenced anywhere in the code base. In fact the raw build output was instead being saved as `xcodebuild-archive.log` and `xcodebuild-export-archive.log` in the case of archive for ipa export.

### Decisions

<!-- Please list decisions that were made for this change. -->

Updated the env var name and file name of the raw log output in the console messaging.
