### PR TITLE
Fix dSYM E2E test after sample app change

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -340,7 +340,7 @@ workflows:
     - IPA_EXPORT_METHOD: development
     - IPA_EXPORT_ICLOUD_CONTAINER_ENVIRONMENT: ""
     - LOG_FORMATTER: xcodebuild
-    - DSYM_EXPECTED_COUNT: 1
+    - DSYM_EXPECTED_COUNT: 2
     after_run:
     - _run
     - _check_outputs

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -370,7 +370,7 @@ workflows:
   test_workspace:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-workspace-swift.git
-    - TEST_APP_BRANCH: "master"
+    - TEST_APP_BRANCH: master
     - BITRISE_PROJECT_PATH: sample-apps-ios-workspace-swift.xcworkspace
     - BITRISE_SCHEME: sample-apps-ios-workspace-swift
     - CODE_SIGNING_METHOD: api-key

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -370,7 +370,7 @@ workflows:
   test_workspace:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-workspace-swift.git
-    - TEST_APP_BRANCH: ""
+    - TEST_APP_BRANCH: "master"
     - BITRISE_PROJECT_PATH: sample-apps-ios-workspace-swift.xcworkspace
     - BITRISE_SCHEME: sample-apps-ios-workspace-swift
     - CODE_SIGNING_METHOD: api-key

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -371,7 +371,6 @@ workflows:
     envs:
     - TEST_APP_URL: https://github.com/bitrise-samples/sample-apps-ios-workspace-swift.git
     - TEST_APP_BRANCH: ""
-    - TEST_APP_COMMIT: 1360413258cc7f6a8676c17f060ff39899fc28b1
     - BITRISE_PROJECT_PATH: sample-apps-ios-workspace-swift.xcworkspace
     - BITRISE_SCHEME: sample-apps-ios-workspace-swift
     - CODE_SIGNING_METHOD: api-key

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -340,7 +340,7 @@ workflows:
     - IPA_EXPORT_METHOD: development
     - IPA_EXPORT_ICLOUD_CONTAINER_ENVIRONMENT: ""
     - LOG_FORMATTER: xcodebuild
-    - DSYM_EXPECTED_COUNT: 3
+    - DSYM_EXPECTED_COUNT: 1
     after_run:
     - _run
     - _check_outputs


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

We bumped the deployment target in the sample app recently that the E2E tests use: https://github.com/bitrise-io/sample-apps-ios-simple-objc/commit/49e64328843dc556ae4befa1d2642e307c71f5cf

After this change, one E2E test fails at this assertion:

```
+ [[ 13 -ge 14 ]]
+ cd /var/folders/sj/_4jj239s3j33w5w1bdh98yj80000gn/T/__dsyms__412218052
++ find . -name '*.dSYM' -maxdepth 1
++ wc -l
+ '[' 2 -ne 3 ']'
+ echo 'error, expected dSYM count (3) doesn\'\''t match folder contents: '
+ ls -la
error, expected dSYM count (3) doesn\'t match folder contents: 
total 0
drwx------    4 [REDACTED]  staff    128 Mar 27 00:11 .
drwx------@ 391 [REDACTED]  staff  12512 Mar 27 00:11 ..
drwxr-xr-x    3 [REDACTED]  staff     96 Mar 27 00:11 8FE341AB-DCCC-391C-BD9A-006491CB73E9.dSYM
drwxr-xr-x    3 [REDACTED]  staff     96 Mar 27 00:11 ios-simple-objc.app.dSYM
+ exit 1
exit status 1
```

### Changes

Adjust the test case to only expect 1 dSYM. Since nothing else change in the step codebase, I think this is just a side-effect of the deployment target change. dSYMs are deprecated anyways and Xcode 14+ doesn't emit them, so I wouldn't worry too much about this.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
