### PR TITLE
Update go-xcode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.23
 	github.com/bitrise-io/go-utils v1.0.11
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.20
-	github.com/bitrise-io/go-xcode v1.0.18
+	github.com/bitrise-io/go-xcode v1.0.19
 	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.40
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.8.4

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/bitrise-io/go-utils v1.0.11 h1:NJ9rRWif4C6nhdh/v6Y/sJZU1UJ+yj0mDgnxsD
 github.com/bitrise-io/go-utils v1.0.11/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.20 h1:R+xJRWsuHhF/Pnx0gjI1+HH4Y0YSFVI+U/CbLpSx4sU=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.20/go.mod h1:Laih4ji980SQkRgdnMCH0g4u2GZI/5nnbqmYT9UfKFQ=
-github.com/bitrise-io/go-xcode v1.0.18 h1:guFywV/AwcZuexqIQkL1ixc3QThpbJvA4voa9MqvPto=
-github.com/bitrise-io/go-xcode v1.0.18/go.mod h1:9OwsvrhZ4A2JxHVoEY7CPcABAKA+OE7FQqFfBfvbFuY=
+github.com/bitrise-io/go-xcode v1.0.19 h1:pbPEIqTHigviG9+1ppMTLv5h6z4k2oz3gKYLKoHJ0yg=
+github.com/bitrise-io/go-xcode v1.0.19/go.mod h1:9OwsvrhZ4A2JxHVoEY7CPcABAKA+OE7FQqFfBfvbFuY=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.40 h1:H4452rgnPqDLRH5mzBvnQ3m7WMt5qZ/RkXFGEFwsXW4=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.40/go.mod h1:Y3K7ay6Q+znVKFmGGvr4jijnN8QmTBxB5+CatRtBl30=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -40,7 +40,7 @@ github.com/bitrise-io/go-utils/v2/log
 github.com/bitrise-io/go-utils/v2/log/colorstring
 github.com/bitrise-io/go-utils/v2/pathutil
 github.com/bitrise-io/go-utils/v2/retryhttp
-# github.com/bitrise-io/go-xcode v1.0.18
+# github.com/bitrise-io/go-xcode v1.0.19
 ## explicit; go 1.20
 github.com/bitrise-io/go-xcode/appleauth
 github.com/bitrise-io/go-xcode/certificateutil


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

This PR updates `go-xcode@v1` dependency to pull a [fix](https://github.com/bitrise-io/go-xcode/pull/234) for the `bufio.Scanner: token too long` error, when the step reads the project's build settings.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

- Update go-xcode@v1
