### PR TITLE
Fix visionOS test targeting

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -25,7 +25,7 @@ workflows:
     - bitrise-run:
         title: Run visionOS test if current stack supports it
         run_if: |-
-            {{ and (ne (getenv "BITRISEIO_STACK_ID") "osx-xcode-15.1.x") (ne (getenv "BITRISEIO_STACK_ID") "osx-xcode-15.0.x") (not (envcontain "BITRISEIO_STACK_ID" "osx-xcode-14.")) }}
+            {{ and (not (envcontain "BITRISEIO_STACK_ID" "osx-xcode-15.0")) (not (envcontain "BITRISEIO_STACK_ID" "osx-xcode-15.1")) (not (envcontain "BITRISEIO_STACK_ID" "osx-xcode-14.")) }}
         inputs:
         - workflow_id: utility_test_visionOS
         - bitrise_config_path: ./e2e/bitrise.yml


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

When running stack tests, these E2E tests also run on Xcode 15.0 Edge and Xcode 15.1 Edge. The run_if condition should filter out the visionOS test on those stacks too.

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
