### PR TITLE
Fix profile cleanup in e2e tests

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -101,8 +101,8 @@ workflows:
         - content: |-
             #!/bin/bash
             set -ex
-            rm -rf "~/Library/MobileDevice/Provisioning Profiles"
-            rm -rf "~/Library/Developer/Xcode/UserData/Provisioning Profiles"
+            rm -rf ~/Library/MobileDevice/Provisioning\ Profiles
+            rm -rf ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git@master:
         inputs:
         - repository_url: https://github.com/bitrise-io/sample-apps-ios-simple-objc.git
@@ -151,8 +151,8 @@ workflows:
         - content: |-
             #!/bin/bash
             set -ex
-            rm -rf "~/Library/MobileDevice/Provisioning Profiles"
-            rm -rf "~/Library/Developer/Xcode/UserData/Provisioning Profiles"
+            rm -rf ~/Library/MobileDevice/Provisioning\ Profiles
+            rm -rf ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
         inputs:
         - repository_url: $TEST_APP_URL
@@ -507,8 +507,8 @@ workflows:
         - content: |-
             #!/bin/bash
             set -ex
-            rm -rf "~/Library/MobileDevice/Provisioning Profiles"
-            rm -rf "~/Library/Developer/Xcode/UserData/Provisioning Profiles"
+            rm -rf ~/Library/MobileDevice/Provisioning\ Profiles
+            rm -rf ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
         inputs:
         - repository_url: $TEST_APP_URL

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -101,8 +101,8 @@ workflows:
         - content: |-
             #!/bin/bash
             set -ex
-            rm -rf ~/Library/MobileDevice/Provisioning\ Profiles
-            rm -rf ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles
+            rm -rf ~/Library/MobileDevice/Provisioning\ Profiles/*
+            rm -rf ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles/*
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git@master:
         inputs:
         - repository_url: https://github.com/bitrise-io/sample-apps-ios-simple-objc.git
@@ -151,8 +151,8 @@ workflows:
         - content: |-
             #!/bin/bash
             set -ex
-            rm -rf ~/Library/MobileDevice/Provisioning\ Profiles
-            rm -rf ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles
+            rm -rf ~/Library/MobileDevice/Provisioning\ Profiles/*
+            rm -rf ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles/*
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
         inputs:
         - repository_url: $TEST_APP_URL
@@ -507,8 +507,8 @@ workflows:
         - content: |-
             #!/bin/bash
             set -ex
-            rm -rf ~/Library/MobileDevice/Provisioning\ Profiles
-            rm -rf ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles
+            rm -rf ~/Library/MobileDevice/Provisioning\ Profiles/*
+            rm -rf ~/Library/Developer/Xcode/UserData/Provisioning\ Profiles/*
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
         inputs:
         - repository_url: $TEST_APP_URL

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -94,6 +94,15 @@ workflows:
             set -ex
             rm -rf "./_tmp"
             mkdir -p "./_tmp"
+    - script:
+        title: Remove provisioning profiles from previous runs
+        run_if: .IsCI
+        inputs:
+        - content: |-
+            #!/bin/bash
+            set -ex
+            rm -rf "~/Library/MobileDevice/Provisioning Profiles"
+            rm -rf "~/Library/Developer/Xcode/UserData/Provisioning Profiles"
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git@master:
         inputs:
         - repository_url: https://github.com/bitrise-io/sample-apps-ios-simple-objc.git
@@ -142,7 +151,8 @@ workflows:
         - content: |-
             #!/bin/bash
             set -ex
-            rm -rf ~/Library/MobileDevice/Provisioning Profiles
+            rm -rf "~/Library/MobileDevice/Provisioning Profiles"
+            rm -rf "~/Library/Developer/Xcode/UserData/Provisioning Profiles"
     - git::https://github.com/bitrise-steplib/bitrise-step-simple-git-clone.git:
         inputs:
         - repository_url: $TEST_APP_URL


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires *NO* [version update](https://semver.org/)

### Context

This PR fixes the provisioning profiles cleanup in the e2e tests.
