### PR TITLE
Include ExtensionKit targets in generated provisioningProfiles.

### DIFF
--- a/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj/target.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj/target.go
@@ -18,7 +18,11 @@ const (
 	LegacyTargetType    TargetType = "PBXLegacyTarget"
 )
 
-const appClipProductType = "com.apple.product-type.application.on-demand-install-capable"
+const (
+	appClipProductType            = "com.apple.product-type.application.on-demand-install-capable"
+	extensionKitExtensionFileExt  = ".extensionkitextension"
+	extensionKitExtensionType     = "com.apple.product-type.extensionkit-extension"
+)
 
 // Target ...
 type Target struct {
@@ -49,7 +53,12 @@ func (t Target) IsAppProduct() bool {
 
 // IsAppExtensionProduct ...
 func (t Target) IsAppExtensionProduct() bool {
-	return filepath.Ext(t.ProductReference.Path) == ".appex"
+	switch filepath.Ext(t.ProductReference.Path) {
+	case ".appex", extensionKitExtensionFileExt:
+		return true
+	}
+
+	return t.ProductType == extensionKitExtensionType
 }
 
 // IsExecutableProduct ...


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *MINOR* [version update](https://semver.org/)

### Context

This step already successfully discovers and generates the export options for `.appex` executable extensions. This PR adds support for the more recent `.extensionkitextension` (ExtensionKit • iOS 16.1+, watchOS 10.0+) executable extensions.

### Changes

- treat ExtensionKit targets (product type `com.apple.product-type.extensionkit-extension`) as executable dependencies
- ensure ExtensionKit bundle IDs are included when generating the `provisioningProfiles` dictionary

### Investigation details

### Decisions
