### PR TITLE
Wrap xcodebuild with Bitrise Build Cache when React Native cache is active

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/bitrise-io/go-xcode/v2/xcodecommand"
 	"github.com/bitrise-io/go-xcode/v2/xcodeversion"
 	"github.com/bitrise-steplib/steps-xcode-archive/step"
+	"github.com/bitrise-steplib/steps-xcode-archive/step/buildcache"
 )
 
 func main() {
@@ -77,12 +79,21 @@ func createXcodebuildArchiver(logger log.Logger, logFormatter string) (step.Xcod
 	cmdFactory := command.NewFactory(envRepository)
 	xcodeVersionReader := xcodeversion.NewXcodeVersionProvider(cmdFactory)
 
+	// Only the factory handed to the xcodecommand runner gets wrapped — codesign,
+	// project readers, and other cmdFactory consumers keep invoking binaries
+	// directly.
+	runnerCmdFactory := cmdFactory
+	if det := buildcache.Detect(context.Background(), logger); det.ReactNativeEnabled {
+		logger.Infof("Bitrise Build Cache: React Native cache active — wrapping xcodebuild with %s", det.CLIPath)
+		runnerCmdFactory = buildcache.NewWrappingCommandFactory(cmdFactory, det.CLIPath)
+	}
+
 	xcodeCommandRunner := xcodecommand.Runner(nil)
 	switch logFormatter {
 	case step.XcodebuildTool:
-		xcodeCommandRunner = xcodecommand.NewRawCommandRunner(logger, cmdFactory)
+		xcodeCommandRunner = xcodecommand.NewRawCommandRunner(logger, runnerCmdFactory)
 	case step.XcbeautifyTool:
-		xcodeCommandRunner = xcodecommand.NewXcbeautifyRunner(logger, cmdFactory)
+		xcodeCommandRunner = xcodecommand.NewXcbeautifyRunner(logger, runnerCmdFactory)
 	case step.XcprettyTool:
 		commandLocator := env.NewCommandLocator()
 		rubyComamndFactory, err := ruby.NewCommandFactory(cmdFactory, commandLocator)
@@ -91,12 +102,12 @@ func createXcodebuildArchiver(logger log.Logger, logFormatter string) (step.Xcod
 		}
 		rubyEnv := ruby.NewEnvironment(rubyComamndFactory, commandLocator, logger)
 
-		xcodeCommandRunner = xcodecommand.NewXcprettyCommandRunner(logger, cmdFactory, pathChecker, fileManager, rubyComamndFactory, rubyEnv)
+		xcodeCommandRunner = xcodecommand.NewXcprettyCommandRunner(logger, runnerCmdFactory, pathChecker, fileManager, rubyComamndFactory, rubyEnv)
 	default:
 		panic(fmt.Sprintf("Unknown log formatter: %s", logFormatter))
 	}
 
-	return step.NewXcodebuildArchiver(xcodeCommandRunner, logFormatter, xcodeVersionReader, pathProvider, pathChecker, pathModifier, fileManager, cmdFactory, logger), nil
+	return step.NewXcodebuildArchiverWithRunnerFactory(xcodeCommandRunner, logFormatter, xcodeVersionReader, pathProvider, pathChecker, pathModifier, fileManager, cmdFactory, runnerCmdFactory, logger), nil
 }
 
 func createRunOptions(config step.Config) step.RunOpts {

--- a/step/buildcache/detect.go
+++ b/step/buildcache/detect.go
@@ -1,0 +1,91 @@
+// Package buildcache detects whether the Bitrise Build Cache CLI is installed
+// on this machine and whether the React Native build cache has been activated.
+// The step uses the result to decide whether to wrap its xcodebuild invocation
+// in `bitrise-build-cache react-native run --`.
+package buildcache
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"time"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+)
+
+const (
+	cliBinary = "bitrise-build-cache"
+
+	lookupTimeout = 2 * time.Second
+	statusTimeout = 5 * time.Second
+)
+
+// Detection describes the CLI's reachability and RN-cache activation state on
+// this machine. A zero-value Detection means "no wrapping should happen" —
+// either because the CLI is absent, unhealthy, or RN cache isn't activated.
+type Detection struct {
+	CLIPath            string
+	ReactNativeEnabled bool
+}
+
+// Detect probes the CLI on PATH and queries RN-enablement. Any failure
+// degrades to a zero-value Detection with a warn log — this function must
+// never cause the step to fail.
+func Detect(ctx context.Context, logger log.Logger) Detection {
+	path, err := exec.LookPath(cliBinary)
+	if err != nil {
+		return Detection{}
+	}
+
+	if err := probeCLI(ctx, path); err != nil {
+		logger.Warnf("Bitrise Build Cache CLI found at %s but --version failed: %s. Skipping RN cache wrap.", path, err)
+
+		return Detection{}
+	}
+
+	enabled, err := queryRNEnabled(ctx, path)
+	if err != nil {
+		logger.Warnf("Bitrise Build Cache status probe failed (%s). Skipping RN cache wrap.", err)
+
+		return Detection{CLIPath: path}
+	}
+
+	return Detection{
+		CLIPath:            path,
+		ReactNativeEnabled: enabled,
+	}
+}
+
+func probeCLI(ctx context.Context, path string) error {
+	ctx, cancel := context.WithTimeout(ctx, lookupTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, path, "--version")
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// queryRNEnabled calls `<cli> status --feature=react-native --quiet`. Exit 0
+// means enabled, exit 1 means disabled. Any other outcome is a probe failure.
+func queryRNEnabled(ctx context.Context, path string) (bool, error) {
+	ctx, cancel := context.WithTimeout(ctx, statusTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, path, "status", "--feature=react-native", "--quiet")
+	err := cmd.Run()
+	if err == nil {
+		return true, nil
+	}
+
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if exitErr.ExitCode() == 1 {
+			return false, nil
+		}
+	}
+
+	return false, err
+}

--- a/step/buildcache/detect_test.go
+++ b/step/buildcache/detect_test.go
@@ -1,0 +1,117 @@
+package buildcache
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetect_NoCLIOnPath(t *testing.T) {
+	emptyDir := t.TempDir()
+	t.Setenv("PATH", emptyDir)
+
+	got := Detect(context.Background(), log.NewLogger())
+
+	assert.Equal(t, Detection{}, got)
+}
+
+func TestDetect_Enabled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub isn't portable to windows")
+	}
+
+	dir := t.TempDir()
+	installStub(t, dir, `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "stub 1.0.0"
+  exit 0
+fi
+if [ "$1" = "status" ] && [ "$2" = "--feature=react-native" ] && [ "$3" = "--quiet" ]; then
+  exit 0
+fi
+exit 99
+`)
+	t.Setenv("PATH", dir)
+
+	got := Detect(context.Background(), log.NewLogger())
+
+	assert.True(t, got.ReactNativeEnabled)
+	assert.Equal(t, filepath.Join(dir, "bitrise-build-cache"), got.CLIPath)
+}
+
+func TestDetect_Disabled(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub isn't portable to windows")
+	}
+
+	dir := t.TempDir()
+	installStub(t, dir, `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  exit 0
+fi
+if [ "$1" = "status" ]; then
+  exit 1
+fi
+exit 99
+`)
+	t.Setenv("PATH", dir)
+
+	got := Detect(context.Background(), log.NewLogger())
+
+	assert.False(t, got.ReactNativeEnabled)
+	assert.Equal(t, filepath.Join(dir, "bitrise-build-cache"), got.CLIPath)
+}
+
+func TestDetect_VersionFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub isn't portable to windows")
+	}
+
+	dir := t.TempDir()
+	installStub(t, dir, `#!/bin/sh
+exit 42
+`)
+	t.Setenv("PATH", dir)
+
+	got := Detect(context.Background(), log.NewLogger())
+
+	// Broken CLI → zero-value (no wrap). CLIPath is left blank so callers
+	// don't accidentally invoke a broken binary later.
+	assert.Equal(t, Detection{}, got)
+}
+
+func TestDetect_StatusFailsUnexpectedly(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub isn't portable to windows")
+	}
+
+	dir := t.TempDir()
+	installStub(t, dir, `#!/bin/sh
+if [ "$1" = "--version" ]; then
+  exit 0
+fi
+if [ "$1" = "status" ]; then
+  exit 7
+fi
+exit 99
+`)
+	t.Setenv("PATH", dir)
+
+	got := Detect(context.Background(), log.NewLogger())
+
+	assert.False(t, got.ReactNativeEnabled)
+	// CLIPath is populated because probeCLI succeeded; only the status probe failed.
+	assert.Equal(t, filepath.Join(dir, "bitrise-build-cache"), got.CLIPath)
+}
+
+func installStub(t *testing.T, dir, script string) {
+	t.Helper()
+	path := filepath.Join(dir, "bitrise-build-cache")
+	require.NoError(t, os.WriteFile(path, []byte(script), 0o755))
+}

--- a/step/buildcache/factory.go
+++ b/step/buildcache/factory.go
@@ -1,0 +1,36 @@
+package buildcache
+
+import (
+	"github.com/bitrise-io/go-utils/v2/command"
+)
+
+// xcodebuildBinary is the command name the go-xcode xcodecommand runners use
+// when invoking xcodebuild. We intercept Create calls with this name and
+// rewrite them to route through `<cli> react-native run -- xcodebuild ...`.
+const xcodebuildBinary = "xcodebuild"
+
+// NewWrappingCommandFactory returns a command.Factory that forwards all calls
+// to inner, except when name == "xcodebuild": those are rewritten to
+// `<cliPath> react-native run -- xcodebuild <args...>` so the invocation runs
+// under Bitrise Build Cache's React Native wrapper. Non-xcodebuild calls
+// (xcbeautify, xcpretty, etc.) pass through untouched.
+func NewWrappingCommandFactory(inner command.Factory, cliPath string) command.Factory {
+	return &wrappingFactory{inner: inner, cliPath: cliPath}
+}
+
+type wrappingFactory struct {
+	inner   command.Factory
+	cliPath string
+}
+
+func (w *wrappingFactory) Create(name string, args []string, opts *command.Opts) command.Command {
+	if name != xcodebuildBinary {
+		return w.inner.Create(name, args, opts)
+	}
+
+	wrappedArgs := make([]string, 0, len(args)+4)
+	wrappedArgs = append(wrappedArgs, "react-native", "run", "--", xcodebuildBinary)
+	wrappedArgs = append(wrappedArgs, args...)
+
+	return w.inner.Create(w.cliPath, wrappedArgs, opts)
+}

--- a/step/buildcache/factory_test.go
+++ b/step/buildcache/factory_test.go
@@ -1,0 +1,36 @@
+package buildcache
+
+import (
+	"testing"
+
+	"github.com/bitrise-io/go-utils/v2/command"
+	"github.com/bitrise-io/go-utils/v2/env"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWrappingFactory_RewritesXcodebuild(t *testing.T) {
+	inner := command.NewFactory(env.NewRepository())
+	wrapped := NewWrappingCommandFactory(inner, "/opt/bin/bitrise-build-cache")
+
+	cmd := wrapped.Create("xcodebuild", []string{"-project", "App.xcodeproj", "archive"}, nil)
+
+	printed := cmd.PrintableCommandArgs()
+	assert.Contains(t, printed, "/opt/bin/bitrise-build-cache")
+	assert.Contains(t, printed, "react-native")
+	assert.Contains(t, printed, "run")
+	assert.Contains(t, printed, "xcodebuild")
+	assert.Contains(t, printed, "-project")
+	assert.Contains(t, printed, "archive")
+}
+
+func TestWrappingFactory_PassesThroughOtherBinaries(t *testing.T) {
+	inner := command.NewFactory(env.NewRepository())
+	wrapped := NewWrappingCommandFactory(inner, "/opt/bin/bitrise-build-cache")
+
+	cmd := wrapped.Create("xcbeautify", []string{"--disable-colored-output"}, nil)
+
+	printed := cmd.PrintableCommandArgs()
+	assert.Contains(t, printed, "xcbeautify")
+	assert.NotContains(t, printed, "bitrise-build-cache")
+	assert.NotContains(t, printed, "react-native")
+}

--- a/step/step.go
+++ b/step/step.go
@@ -156,6 +156,10 @@ type XcodebuildArchiver struct {
 	fileManager        fileutil.FileManager
 	logger             log.Logger
 	cmdFactory         command.Factory
+	// xcodeRunnerCmdFactory is the factory used to (re)build xcodecommand runners.
+	// It matches cmdFactory for raw setups, or is wrapped with Bitrise Build Cache
+	// when RN cache activation was detected at main.go wiring time.
+	xcodeRunnerCmdFactory command.Factory
 }
 
 func NewXcodeArchiveConfigParser(stepInputParser stepconf.InputParser, xcodeVersionReader xcodeversion.Reader, fileManager fileutil.FileManager, cmdFactory command.Factory, projectFactory projectmanager.Factory, logger log.Logger) XcodebuildArchiveConfigParser {
@@ -171,16 +175,26 @@ func NewXcodeArchiveConfigParser(stepInputParser stepconf.InputParser, xcodeVers
 
 // NewXcodebuildArchiver ...
 func NewXcodebuildArchiver(xcodecommandRunner xcodecommand.Runner, logFormatter string, xcodeVersionReader xcodeversion.Reader, pathProvider pathutil.PathProvider, pathChecker pathutil.PathChecker, pathModifier pathutil.PathModifier, fileManager fileutil.FileManager, cmdFactory command.Factory, logger log.Logger) XcodebuildArchiver {
+	return NewXcodebuildArchiverWithRunnerFactory(xcodecommandRunner, logFormatter, xcodeVersionReader, pathProvider, pathChecker, pathModifier, fileManager, cmdFactory, cmdFactory, logger)
+}
+
+// NewXcodebuildArchiverWithRunnerFactory is a variant of NewXcodebuildArchiver
+// that accepts a separate factory for xcodecommand.Runner construction. When
+// Bitrise Build Cache wraps xcodebuild, the runner factory is a wrapping
+// factory while cmdFactory remains unwrapped — so codesign / project reader
+// invocations stay unaffected.
+func NewXcodebuildArchiverWithRunnerFactory(xcodecommandRunner xcodecommand.Runner, logFormatter string, xcodeVersionReader xcodeversion.Reader, pathProvider pathutil.PathProvider, pathChecker pathutil.PathChecker, pathModifier pathutil.PathModifier, fileManager fileutil.FileManager, cmdFactory, xcodeRunnerCmdFactory command.Factory, logger log.Logger) XcodebuildArchiver {
 	return XcodebuildArchiver{
-		xcodeCommandRunner: xcodecommandRunner,
-		logFormatter:       logFormatter,
-		xcodeVersionReader: xcodeVersionReader,
-		pathProvider:       pathProvider,
-		pathChecker:        pathChecker,
-		pathModifier:       pathModifier,
-		fileManager:        fileManager,
-		logger:             logger,
-		cmdFactory:         cmdFactory,
+		xcodeCommandRunner:    xcodecommandRunner,
+		logFormatter:          logFormatter,
+		xcodeVersionReader:    xcodeVersionReader,
+		pathProvider:          pathProvider,
+		pathChecker:           pathChecker,
+		pathModifier:          pathModifier,
+		fileManager:           fileManager,
+		logger:                logger,
+		cmdFactory:            cmdFactory,
+		xcodeRunnerCmdFactory: xcodeRunnerCmdFactory,
 	}
 }
 
@@ -329,7 +343,7 @@ func (s *XcodebuildArchiver) EnsureDependencies() {
 		s.logger.Infof("Switching back to xcodebuild log formatter.")
 
 		s.logFormatter = XcodebuildTool
-		s.xcodeCommandRunner = xcodecommand.NewRawCommandRunner(s.logger, s.cmdFactory)
+		s.xcodeCommandRunner = xcodecommand.NewRawCommandRunner(s.logger, s.xcodeRunnerCmdFactory)
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Detect the `bitrise-build-cache` CLI on PATH and query `status --feature=react-native --quiet` at step startup
- When RN cache is enabled, wrap xcodebuild archive + export invocations with `bitrise-build-cache react-native run -- xcodebuild ...`
- Activation is fully automatic — no new step inputs. Controlled by the CLI's `activate react-native` command
- Only the factory passed to the xcodecommand runner is wrapped; codesign, project readers, xcbeautify, and xcpretty invocations pass through unchanged
- Detection failures (missing CLI, broken `--version`, unexpected status exit) degrade silently with a warn log — never fails the step

## Implementation notes
- `step/buildcache/detect.go` — CLI detection, mirrors the helper in the Android step repo
- `step/buildcache/factory.go` — wrapping `command.Factory` that intercepts `Create("xcodebuild", ...)` and rewrites to `Create(cliPath, prepend("react-native","run","--","xcodebuild", args), opts)`; other binaries pass through
- `main.go` — detect once, pass wrapped factory to the xcodecommand runner constructor only (raw/xcbeautify/xcpretty all benefit)
- `step/step.go` — `XcodebuildArchiver` gained an `xcodeRunnerCmdFactory` field so the `EnsureDependencies` fallback (which rebuilds a raw runner when the selected log formatter is unavailable) also stays wrapped. Added `NewXcodebuildArchiverWithRunnerFactory` for main.go; the original `NewXcodebuildArchiver` is kept and delegates with `cmdFactory` for both fields (no behavior change for existing callers)

## Test plan
- [ ] Unit tests (`go test ./step/buildcache/...`) pass locally
- [ ] E2E: install `bitrise-build-cache` CLI, run `bitrise-build-cache activate react-native`, trigger the step — xcodebuild log should show wrapped command line
- [ ] E2E: step runs unchanged when CLI is absent from PATH
- [ ] E2E: step runs unchanged when `bitrise-build-cache status --feature=react-native --quiet` exits 1 (disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)