### PR TITLE
fix: unlock keychain before SPM package resolution (SSW-3035)

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,7 +120,9 @@ func createRunOptions(config step.Config) step.RunOpts {
 		XcodeMajorVersion:   config.XcodeMajorVersion,
 		ArtifactName:        config.ArtifactName,
 
-		CodesignManager: config.CodesignManager,
+		CodesignManager:  config.CodesignManager,
+		KeychainPath:     config.KeychainPath,
+		KeychainPassword: config.KeychainPassword,
 
 		PerformCleanAction:          config.PerformCleanAction,
 		XcconfigContent:             config.XcconfigContent,

--- a/step/step.go
+++ b/step/step.go
@@ -353,6 +353,19 @@ func (s *XcodebuildArchiver) EnsureDependencies() {
 	}
 }
 
+// unlockKeychain unlocks the given keychain so that operations needing its
+// stored credentials (e.g. resolving private Swift packages over authenticated
+// git remotes) don't block on an interactive unlock prompt.
+func (s XcodebuildArchiver) unlockKeychain(path string, password stepconf.Secret) error {
+	// Mirrors go-xcode's keychain package: `security -v unlock-keychain -p <password> <path>`.
+	// The command args (including the password) are intentionally not logged.
+	cmd := s.cmdFactory.Create("security", []string{"-v", "unlock-keychain", "-p", string(password), path}, nil)
+	if out, err := cmd.RunAndReturnTrimmedCombinedOutput(); err != nil {
+		return fmt.Errorf("%w: %s", err, out)
+	}
+	return nil
+}
+
 // RunOpts ...
 type RunOpts struct {
 	// Shared
@@ -365,7 +378,9 @@ type RunOpts struct {
 	ArtifactName        string
 
 	// Code signing, nil if automatic code signing is "off"
-	CodesignManager *codesign.Manager
+	CodesignManager  *codesign.Manager
+	KeychainPath     string
+	KeychainPassword stepconf.Secret
 
 	// Archive
 	PerformCleanAction          bool
@@ -404,10 +419,51 @@ func (s XcodebuildArchiver) Run(opts RunOpts) (RunResult, error) {
 
 	s.logger.Println()
 
-	// Prepare code signing assets (and unlock the keychain) before resolving Swift
-	// package dependencies. Resolving private SPM packages may require credentials
-	// stored in the keychain; if the keychain is still locked at that point the
-	// build can hang waiting for an interactive unlock prompt.
+	// Unlock the keychain before resolving Swift package dependencies.
+	//
+	// Resolving private SPM packages needs the git credentials stored in the
+	// keychain. The Swift package resolution phase runs before code signing
+	// preparation on purpose (to pre-clone packages so the later
+	// -showBuildSettings calls are fast and don't time out), but that means the
+	// keychain is not unlocked yet by the time we resolve. With a locked
+	// keychain, resolving private packages - and the -showBuildSettings call
+	// made during code signing preparation - can hang waiting for an
+	// interactive unlock prompt that never comes on CI.
+	if opts.CodesignManager != nil && opts.KeychainPath != "" {
+		s.logger.Infof("Unlocking keychain before resolving Swift package dependencies")
+		if err := s.unlockKeychain(opts.KeychainPath, opts.KeychainPassword); err != nil {
+			s.logger.Warnf("Failed to unlock keychain: %s", err)
+		}
+		s.logger.Println()
+	}
+
+	if opts.XcodeMajorVersion >= 11 {
+		s.logger.Infof("Running resolve Swift package dependencies")
+		// Resolve Swift package dependencies, so running -showBuildSettings later is faster later
+		// Specifying a scheme is required for workspaces
+		resolveDepsCmd := xcodebuild.NewResolvePackagesCommandModel(opts.ProjectPath, opts.Scheme, opts.Configuration)
+		resolveDepsCmd.SetCustomOptions(opts.XcodebuildAdditionalOptions)
+		if err := resolveDepsCmd.Run(); err != nil {
+			s.logger.Warnf("%s", err)
+		}
+	}
+
+	if opts.ArtifactName == "" {
+		s.logger.Infof("Looking for artifact name as field is empty")
+
+		productName, err := opts.ProjectManager.ReadSchemeBuildSettingString("PRODUCT_NAME")
+		if err != nil && !serialized.IsKeyNotFoundError(err) {
+			return out, fmt.Errorf("failed to read product name build setting: %w", err)
+		}
+		if productName == "" {
+			s.logger.Warnf("Product name not found in build settings, using scheme (%s) as artifact name", opts.Scheme)
+			productName = opts.Scheme
+		}
+
+		opts.ArtifactName = productName
+	}
+	out.ArtifactName = opts.ArtifactName
+
 	if opts.CodesignManager != nil {
 		s.logger.Infof("Preparing code signing assets (certificates, profiles) before Archive action")
 
@@ -438,33 +494,6 @@ func (s XcodebuildArchiver) Run(opts RunOpts) (RunResult, error) {
 		s.logger.Infof("Automatic code signing is disabled, skipped downloading code sign assets")
 	}
 	s.logger.Println()
-
-	if opts.XcodeMajorVersion >= 11 {
-		s.logger.Infof("Running resolve Swift package dependencies")
-		// Resolve Swift package dependencies, so running -showBuildSettings later is faster later
-		// Specifying a scheme is required for workspaces
-		resolveDepsCmd := xcodebuild.NewResolvePackagesCommandModel(opts.ProjectPath, opts.Scheme, opts.Configuration)
-		resolveDepsCmd.SetCustomOptions(opts.XcodebuildAdditionalOptions)
-		if err := resolveDepsCmd.Run(); err != nil {
-			s.logger.Warnf("%s", err)
-		}
-	}
-
-	if opts.ArtifactName == "" {
-		s.logger.Infof("Looking for artifact name as field is empty")
-
-		productName, err := opts.ProjectManager.ReadSchemeBuildSettingString("PRODUCT_NAME")
-		if err != nil && !serialized.IsKeyNotFoundError(err) {
-			return out, fmt.Errorf("failed to read product name build setting: %w", err)
-		}
-		if productName == "" {
-			s.logger.Warnf("Product name not found in build settings, using scheme (%s) as artifact name", opts.Scheme)
-			productName = opts.Scheme
-		}
-
-		opts.ArtifactName = productName
-	}
-	out.ArtifactName = opts.ArtifactName
 
 	archiveOpts := xcodeArchiveOpts{
 		ProjectManager:      opts.ProjectManager,

--- a/step/step.go
+++ b/step/step.go
@@ -404,33 +404,10 @@ func (s XcodebuildArchiver) Run(opts RunOpts) (RunResult, error) {
 
 	s.logger.Println()
 
-	if opts.XcodeMajorVersion >= 11 {
-		s.logger.Infof("Running resolve Swift package dependencies")
-		// Resolve Swift package dependencies, so running -showBuildSettings later is faster later
-		// Specifying a scheme is required for workspaces
-		resolveDepsCmd := xcodebuild.NewResolvePackagesCommandModel(opts.ProjectPath, opts.Scheme, opts.Configuration)
-		resolveDepsCmd.SetCustomOptions(opts.XcodebuildAdditionalOptions)
-		if err := resolveDepsCmd.Run(); err != nil {
-			s.logger.Warnf("%s", err)
-		}
-	}
-
-	if opts.ArtifactName == "" {
-		s.logger.Infof("Looking for artifact name as field is empty")
-
-		productName, err := opts.ProjectManager.ReadSchemeBuildSettingString("PRODUCT_NAME")
-		if err != nil && !serialized.IsKeyNotFoundError(err) {
-			return out, fmt.Errorf("failed to read product name build setting: %w", err)
-		}
-		if productName == "" {
-			s.logger.Warnf("Product name not found in build settings, using scheme (%s) as artifact name", opts.Scheme)
-			productName = opts.Scheme
-		}
-
-		opts.ArtifactName = productName
-	}
-	out.ArtifactName = opts.ArtifactName
-
+	// Prepare code signing assets (and unlock the keychain) before resolving Swift
+	// package dependencies. Resolving private SPM packages may require credentials
+	// stored in the keychain; if the keychain is still locked at that point the
+	// build can hang waiting for an interactive unlock prompt.
 	if opts.CodesignManager != nil {
 		s.logger.Infof("Preparing code signing assets (certificates, profiles) before Archive action")
 
@@ -461,6 +438,33 @@ func (s XcodebuildArchiver) Run(opts RunOpts) (RunResult, error) {
 		s.logger.Infof("Automatic code signing is disabled, skipped downloading code sign assets")
 	}
 	s.logger.Println()
+
+	if opts.XcodeMajorVersion >= 11 {
+		s.logger.Infof("Running resolve Swift package dependencies")
+		// Resolve Swift package dependencies, so running -showBuildSettings later is faster later
+		// Specifying a scheme is required for workspaces
+		resolveDepsCmd := xcodebuild.NewResolvePackagesCommandModel(opts.ProjectPath, opts.Scheme, opts.Configuration)
+		resolveDepsCmd.SetCustomOptions(opts.XcodebuildAdditionalOptions)
+		if err := resolveDepsCmd.Run(); err != nil {
+			s.logger.Warnf("%s", err)
+		}
+	}
+
+	if opts.ArtifactName == "" {
+		s.logger.Infof("Looking for artifact name as field is empty")
+
+		productName, err := opts.ProjectManager.ReadSchemeBuildSettingString("PRODUCT_NAME")
+		if err != nil && !serialized.IsKeyNotFoundError(err) {
+			return out, fmt.Errorf("failed to read product name build setting: %w", err)
+		}
+		if productName == "" {
+			s.logger.Warnf("Product name not found in build settings, using scheme (%s) as artifact name", opts.Scheme)
+			productName = opts.Scheme
+		}
+
+		opts.ArtifactName = productName
+	}
+	out.ArtifactName = opts.ArtifactName
 
 	archiveOpts := xcodeArchiveOpts{
 		ProjectManager:      opts.ProjectManager,


### PR DESCRIPTION
## Summary

Fixes [SSW-3035](https://bitrise.atlassian.net/browse/SSW-3035): users' builds hang during codesigning.

The build hangs at code signing preparation's `IsSigningManagedAutomatically()` → `xcodebuild -showBuildSettings` call:

```
Preparing code signing assets (certificates, profiles) before Archive action
Reading build settings...
$ xcodebuild ... -showBuildSettings -onlyUsePackageVersionsFromResolvedFile
```

### Root cause

Resolving **private** Swift packages needs the git credentials stored in the keychain. The step resolves Swift packages *before* code signing preparation on purpose — pre-cloning packages so the later `-showBuildSettings` calls are fast and don't time out. But that means the keychain isn't unlocked yet when packages are resolved (the keychain only gets unlocked as a side effect of `installCertificates` during code signing prep).

With a locked keychain:
- The resolve phase can't clone private packages.
- The subsequent `-showBuildSettings` then tries to access those packages and hangs waiting for an interactive keychain-unlock prompt that never comes on CI.

### Fix

Add a dedicated keychain unlock **before** the Swift package resolution phase, while keeping the resolve-before-codesign ordering intact (so the timeout workaround that ordering provides is preserved).

- `RunOpts` gains `KeychainPath` / `KeychainPassword`, wired from config in `main.go`.
- New `unlockKeychain` helper runs `security -v unlock-keychain` (mirrors go-xcode's keychain package; command args incl. the password are not logged).
- Unlock only runs when automatic code signing is active (`CodesignManager != nil`) and a keychain path is set; failures are warned, not fatal.

> Note: an earlier revision of this PR simply moved the entire code signing prep ahead of resolve — that was reverted because it would reintroduce the `-showBuildSettings` timeout the resolve phase was added to prevent.

## Test plan

- `go build ./...` — clean
- `go test ./step/...` — passes
- `go vet ./step/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SSW-3035]: https://bitrise.atlassian.net/browse/SSW-3035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ