### PR TITLE
Bump go-xcode to v1.3.4 (Xcode 26 / objectVersion 90 support)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.50
 	github.com/bitrise-io/go-utils v1.0.15
 	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34
-	github.com/bitrise-io/go-xcode v1.3.3
+	github.com/bitrise-io/go-xcode v1.3.4
 	github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.81
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -13,8 +13,8 @@ github.com/bitrise-io/go-utils v1.0.15 h1:KRQjNiPrkxBRM6G5fQy05v0p0r8wycWfKVb+Ko
 github.com/bitrise-io/go-utils v1.0.15/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34 h1:xsLfhItfs4SCCAesbv7UtKpldNqievDvtHggSuBI2+w=
 github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
-github.com/bitrise-io/go-xcode v1.3.3 h1:aYkSMWP+1/n2ZabRy3OMfeaWmE4l1gAPq63azx06LIw=
-github.com/bitrise-io/go-xcode v1.3.3/go.mod h1:9OwsvrhZ4A2JxHVoEY7CPcABAKA+OE7FQqFfBfvbFuY=
+github.com/bitrise-io/go-xcode v1.3.4 h1:etCBcNIwTBu0NJzYFBxNm0APxE11urlVlmUP0YE8sto=
+github.com/bitrise-io/go-xcode v1.3.4/go.mod h1:9OwsvrhZ4A2JxHVoEY7CPcABAKA+OE7FQqFfBfvbFuY=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.81 h1:TOAgsu10sunsdEGPzElb8S7NSavTrtpRNgopsjWt0mk=
 github.com/bitrise-io/go-xcode/v2 v2.0.0-alpha.81/go.mod h1:YspByJ93D3uuDoCMCw0BZLT6rl77YUohOb4b+lBaMTQ=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=

--- a/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj/target.go
+++ b/vendor/github.com/bitrise-io/go-xcode/xcodeproject/xcodeproj/target.go
@@ -129,7 +129,10 @@ func parseTarget(id string, objects serialized.Object) (Target, error) {
 
 	dependencyIDs, err := rawTarget.StringSlice("dependencies")
 	if err != nil {
-		return Target{}, err
+		if !serialized.IsKeyNotFoundError(err) {
+			return Target{}, err
+		}
+		dependencyIDs = []string{}
 	}
 
 	var dependencies []TargetDependency
@@ -168,7 +171,10 @@ func parseTarget(id string, objects serialized.Object) (Target, error) {
 
 	buildPhaseIDs, err := rawTarget.StringSlice("buildPhases")
 	if err != nil {
-		return Target{}, err
+		if !serialized.IsKeyNotFoundError(err) {
+			return Target{}, err
+		}
+		buildPhaseIDs = []string{}
 	}
 
 	return Target{

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -53,7 +53,7 @@ github.com/bitrise-io/go-utils/v2/parseutil
 github.com/bitrise-io/go-utils/v2/pathutil
 github.com/bitrise-io/go-utils/v2/retry
 github.com/bitrise-io/go-utils/v2/retryhttp
-# github.com/bitrise-io/go-xcode v1.3.3
+# github.com/bitrise-io/go-xcode v1.3.4
 ## explicit; go 1.20
 github.com/bitrise-io/go-xcode/certificateutil
 github.com/bitrise-io/go-xcode/exportoptions


### PR DESCRIPTION
## Summary
Bumps `github.com/bitrise-io/go-xcode` from `v1.3.3` to `v1.3.4`.

## Why
The bundled go-xcode `v1.3.3` fails to parse `.xcodeproj` files saved by Xcode 26 (`objectVersion = 90`). In that format Xcode omits empty `dependencies = ()` collections on targets that have no target dependencies (e.g. app-extension targets). The `v1.3.3` PBX target parser treats `dependencies` as a required key and errors out before `xcodebuild` is ever invoked:

```
failed to open Project or Workspace:
  could not get scheme `...` from path (...):
    failed to parse target with id: ...: key: string("dependencies") not found
```

This makes the **Xcode Archive & Export** step (`6.1.0`, which pins `go-xcode v1.3.3`) unusable on projects opened/saved by the Xcode 26 GUI whenever a target has no explicit dependencies.

go-xcode `v1.3.4` (bitrise-io/go-xcode#331, "treat dependencies and buildPhases as optional keys") fixes exactly this.

## Changes
- `go.mod`: `go-xcode v1.3.3` → `v1.3.4`
- `go.sum`: updated checksums (go-xcode's own `go.mod` is unchanged between the two versions — no transitive dependency changes)

## Test
`go.sum` checksums verified against `sum.golang.org`. I'm an external contributor so I can't run the secret-gated e2e suite — happy for maintainers to run it.
